### PR TITLE
Introduce mkvpropedit argument building

### DIFF
--- a/src/MatroskaBatchFlow.Core/Enums/TrackType.cs
+++ b/src/MatroskaBatchFlow.Core/Enums/TrackType.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace MatroskaBatchFlow.Core.Enums;
 
 /// <summary>
@@ -46,6 +48,22 @@ public static class TrackTypeExtensions
         {
             TrackType.Audio or TrackType.Video or TrackType.Text => true,
             _ => false
+        };
+    }
+
+    /// <summary>
+    /// Gets the Matroska track type prefix corresponding to the specified <see cref="TrackType"/>.
+    /// </summary>
+    /// <param name="trackType">The track type for which to retrieve the Matroska prefix.</param>
+    /// <returns>A string representing the Matroska track type prefix.</returns>
+    public static string GetMatroskaTrackTypePrefix(this TrackType trackType)
+    {
+        return trackType switch
+        {
+            TrackType.Video => "v",
+            TrackType.Audio => "a",
+            TrackType.Text => "s",
+            _ => string.Empty
         };
     }
 }

--- a/src/MatroskaBatchFlow.Core/Services/BatchConfiguration.cs
+++ b/src/MatroskaBatchFlow.Core/Services/BatchConfiguration.cs
@@ -14,6 +14,7 @@ public class BatchConfiguration : INotifyPropertyChanged, IBatchConfiguration
 {
     private string _directoryPath = string.Empty;
     private string _title = string.Empty;
+    private readonly ObservableCollection<ScannedFileInfo> _fileList = [];
     private ObservableCollection<TrackConfiguration> _audioTracks = [];
     private ObservableCollection<TrackConfiguration> _videoTracks = [];
     private ObservableCollection<TrackConfiguration> _subtitleTracks = [];
@@ -46,6 +47,8 @@ public class BatchConfiguration : INotifyPropertyChanged, IBatchConfiguration
             }
         }
     }
+
+    public ObservableCollection<ScannedFileInfo> FileList => _fileList;
 
     public ObservableCollection<TrackConfiguration> AudioTracks
     {
@@ -96,6 +99,7 @@ public class BatchConfiguration : INotifyPropertyChanged, IBatchConfiguration
     {
         DirectoryPath = string.Empty;
         Title = string.Empty;
+        FileList.Clear();
         AudioTracks.Clear();
         VideoTracks.Clear();
         SubtitleTracks.Clear();

--- a/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/IMkvPropeditArgumentsBuilder.cs
+++ b/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/IMkvPropeditArgumentsBuilder.cs
@@ -1,0 +1,10 @@
+using MatroskaBatchFlow.Core.Services.Builders.MkvPropeditArguments.TrackOptions;
+
+namespace MatroskaBatchFlow.Core.Services.Builders.MkvPropeditArguments;
+public interface IMkvPropeditArgumentsBuilder
+{
+    IMkvPropeditArgumentsBuilder SetInputFile(string filePath);
+    IMkvPropeditArgumentsBuilder WithTitle(string title);
+    IMkvPropeditArgumentsBuilder AddTrack(Func<ITrackOptionsBuilder, ITrackOptionsBuilder> func);
+    string[] Build();
+}

--- a/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/MkvPropeditArgumentsBuilder.cs
+++ b/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/MkvPropeditArgumentsBuilder.cs
@@ -1,0 +1,52 @@
+using MatroskaBatchFlow.Core.Services.Builders.MkvPropeditArguments.TrackOptions;
+
+namespace MatroskaBatchFlow.Core.Services.Builders.MkvPropeditArguments;
+public class MkvPropeditArgumentsBuilder : IMkvPropeditArgumentsBuilder
+{
+    private readonly List<TrackOptionsBuilder> _trackOptionsBuilders = [];
+    private string? _inputFile;
+    private string? _title;
+    public IMkvPropeditArgumentsBuilder SetInputFile(string filePath)
+    {
+        _inputFile = filePath;
+        return this;
+    }
+    public IMkvPropeditArgumentsBuilder WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+    public IMkvPropeditArgumentsBuilder AddTrack(Func<ITrackOptionsBuilder, ITrackOptionsBuilder> func)
+    {
+        var trackOptionsBuilder = new TrackOptionsBuilder();
+        func(trackOptionsBuilder);
+        _trackOptionsBuilders.Add(trackOptionsBuilder);
+        return this;
+    }
+
+    public string[] Build()
+    {
+        if (string.IsNullOrEmpty(_inputFile))
+            throw new InvalidOperationException("Target file (input) must be specified.");
+
+        var args = new List<string>
+        {
+            $"{_inputFile}"
+        };
+
+        // Add the segment title if specified.
+        if (_title is not null)
+        {
+            args.Add($"--edit");
+            args.Add("info");
+            args.Add($"--set");
+            args.Add($"title=\"{_title}\"");
+        }
+
+        // Add each track's options.
+        foreach (var tob in _trackOptionsBuilders)
+            args.AddRange(tob.Build());
+
+        return [.. args];
+    }
+}

--- a/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/TrackOptions/ITrackOptionsBuilder.cs
+++ b/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/TrackOptions/ITrackOptionsBuilder.cs
@@ -1,0 +1,15 @@
+using MatroskaBatchFlow.Core.Enums;
+
+namespace MatroskaBatchFlow.Core.Services.Builders.MkvPropeditArguments.TrackOptions;
+public interface ITrackOptionsBuilder
+{
+    ITrackOptionsBuilder SetTrackId(int trackId);
+    ITrackOptionsBuilder SetTrackType(TrackType trackType);
+    ITrackOptionsBuilder WithLanguage(string language);
+    ITrackOptionsBuilder WithName(string name);
+    ITrackOptionsBuilder WithIsDefault(bool isDefault);
+    ITrackOptionsBuilder WithIsForced(bool isForced);
+    ITrackOptionsBuilder WithIsEnabled(bool isEnabled);
+    ITrackOptionsBuilder WithIsCommentary(bool isCommentary);
+    string[] Build();
+}

--- a/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/TrackOptions/TrackOptions.cs
+++ b/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/TrackOptions/TrackOptions.cs
@@ -1,0 +1,14 @@
+using MatroskaBatchFlow.Core.Enums;
+
+namespace MatroskaBatchFlow.Core.Services.Builders.MkvPropeditArguments.TrackOptions;
+internal class TrackOptions
+{
+    public int? TrackId { get; set; }
+    public TrackType? TrackType { get; set; }
+    public string? Language { get; set; }
+    public string? Name { get; set; }
+    public bool? IsDefault { get; set; }
+    public bool? IsForced { get; set; }
+    public bool? IsEnabled { get; set; }
+    public bool? IsCommentary { get; set; }
+}

--- a/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/TrackOptions/TrackOptionsBuilder.cs
+++ b/src/MatroskaBatchFlow.Core/Services/Builders/MkvPropeditArguments/TrackOptions/TrackOptionsBuilder.cs
@@ -1,0 +1,87 @@
+using MatroskaBatchFlow.Core.Enums;
+
+namespace MatroskaBatchFlow.Core.Services.Builders.MkvPropeditArguments.TrackOptions;
+internal class TrackOptionsBuilder : ITrackOptionsBuilder
+{
+    private readonly TrackOptions _trackOptions = new();
+    public ITrackOptionsBuilder SetTrackId(int trackId)
+    {
+        _trackOptions.TrackId = trackId;
+        return this;
+    }
+    public ITrackOptionsBuilder SetTrackType(TrackType trackType)
+    {
+        _trackOptions.TrackType = trackType;
+        return this;
+    }
+    public ITrackOptionsBuilder WithLanguage(string language)
+    {
+        _trackOptions.Language = language;
+        return this;
+    }
+    public ITrackOptionsBuilder WithName(string name)
+    {
+        _trackOptions.Name = name;
+        return this;
+    }
+    public ITrackOptionsBuilder WithIsDefault(bool isDefault)
+    {
+        _trackOptions.IsDefault = isDefault;
+        return this;
+    }
+    public ITrackOptionsBuilder WithIsForced(bool isForced)
+    {
+        _trackOptions.IsForced = isForced;
+        return this;
+    }
+    public ITrackOptionsBuilder WithIsEnabled(bool isEnabled)
+    {
+        _trackOptions.IsEnabled = isEnabled;
+        return this;
+    }
+    public ITrackOptionsBuilder WithIsCommentary(bool isCommentary)
+    {
+        _trackOptions.IsCommentary = isCommentary;
+        return this;
+    }
+
+    public string[] Build()
+    {
+        if (_trackOptions.TrackId is null)
+            throw new InvalidOperationException("Track ID must be specified.");
+        if (_trackOptions.TrackType is null)
+            throw new InvalidOperationException("Track type must be specified.");
+
+        var t = _trackOptions;
+        var args = new List<string>();
+        // e.g., "track:v1" for video track 1.
+        string selector = $"track:{t.TrackType.Value.GetMatroskaTrackTypePrefix()}{t.TrackId}";
+
+        // Begin editing this track.
+        args.Add("--edit");
+        args.Add(selector);
+
+        void AddSet(string key, string value)
+        {
+            args.Add("--set");
+            args.Add($"{key}={value}");
+        }
+
+        if (t.Language is not null)
+            AddSet("language", t.Language);
+
+        if (t.Name is not null)
+            AddSet("name", t.Name);
+
+        if (t.IsDefault.HasValue)
+            AddSet("flag-default", t.IsDefault.Value ? "1" : "0");
+
+        if (t.IsForced.HasValue)
+            AddSet("flag-forced", t.IsForced.Value ? "1" : "0");
+
+        if (t.IsEnabled.HasValue)
+            AddSet("flag-enabled", t.IsEnabled.Value ? "1" : "0");
+
+        return [.. args];
+    }
+}

--- a/src/MatroskaBatchFlow.Core/Services/IBatchConfiguration.cs
+++ b/src/MatroskaBatchFlow.Core/Services/IBatchConfiguration.cs
@@ -14,6 +14,8 @@ public interface IBatchConfiguration : INotifyPropertyChanged
 {
     string DirectoryPath { get; set; }
     string Title { get; set; }
+
+    ObservableCollection<ScannedFileInfo> FileList { get; }
     ObservableCollection<TrackConfiguration> AudioTracks { get; set; }
     ObservableCollection<TrackConfiguration> VideoTracks { get; set; }
     ObservableCollection<TrackConfiguration> SubtitleTracks { get; set; }

--- a/src/MatroskaBatchFlow.Uno/Presentation/InputViewModel.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/InputViewModel.cs
@@ -12,11 +12,8 @@ using Uno.Extensions.Specialized;
 
 namespace MatroskaBatchFlow.Uno.Presentation;
 
-public partial class InputViewModel :ObservableObject, IFilesDropped
+public partial class InputViewModel : ObservableObject, IFilesDropped
 {
-    [ObservableProperty]
-    private ObservableCollection<ScannedFileInfo> fileList = [];
-
     [ObservableProperty]
     private ObservableCollection<ScannedFileInfo> selectedFiles = [];
 
@@ -31,6 +28,8 @@ public partial class InputViewModel :ObservableObject, IFilesDropped
     private readonly IBatchConfigurationTrackInitializer _batchConfigurationTrackInitializer;
 
     public ICommand RemoveSelected { get; }
+
+    public ObservableCollection<ScannedFileInfo> FileList => _batchConfig.FileList;
 
     public InputViewModel(
         IFileScanner fileScanner,
@@ -53,13 +52,13 @@ public partial class InputViewModel :ObservableObject, IFilesDropped
     /// cref="FileList"/>.
     /// </summary>
     /// <remarks>This method processes the removal of selected files by iterating over a copy of the <see
-    /// cref="SelectedFiles"/> collection..</remarks>
+    /// cref="SelectedFiles"/> collection.</remarks>
     /// <returns>A completed <see cref="Task"/> representing the operation.</returns>
     private Task RemoveSelectedFiles()
     {
         // Convert SelectedFiles to an array to make a copy to avoid modifying the collection while iterating.
         foreach (ScannedFileInfo file in SelectedFiles.ToArray())
-            FileList.Remove(file);
+            _batchConfig.FileList.Remove(file);
 
         return Task.CompletedTask;
     }
@@ -77,7 +76,7 @@ public partial class InputViewModel :ObservableObject, IFilesDropped
             return;
 
         var newFiles = await _fileScanner.ScanAsync(files.ToFileInfo());
-        var combinedFiles = FileList.Concat(newFiles).ToList();
+        var combinedFiles = _batchConfig.FileList.Concat(newFiles).ToList();
 
         // Validate the combined list of files, including both existing and newly added files.
         var validationResults = _fileValidator.Validate(combinedFiles).ToList();
@@ -91,7 +90,7 @@ public partial class InputViewModel :ObservableObject, IFilesDropped
             _fileProcessingRuleEngine.Apply(file, _batchConfig);
         }
 
-        FileList.AddRange(newFiles);
+        _batchConfig.FileList.AddRange(newFiles);
     }
 
     /// <summary>

--- a/src/MatroskaBatchFlow.Uno/Presentation/MainPage.xaml
+++ b/src/MatroskaBatchFlow.Uno/Presentation/MainPage.xaml
@@ -45,10 +45,24 @@
                 </Grid>
             </Grid>
         </NavigationView>
-        <Button Content="Process Files"
-                Grid.Row="1"
-                Margin="10,10,10,10"
-                HorizontalAlignment="Center"
-                Command="{Binding ScanFiles}"/>
+        <StackPanel Grid.Row="1"
+                    HorizontalAlignment="Center">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="auto" />
+                </Grid.ColumnDefinitions>
+                <Button Content="Process Files"
+                        Grid.Column="0"
+                        Margin="10,10,10,10"
+                        HorizontalAlignment="Center"
+                        Command="{Binding ScanFiles}"/>
+                <Button Content="Generate mkvpropedit"
+                        Grid.Column="1"
+                        Margin="10,10,10,10"
+                        HorizontalAlignment="Center"
+                        Command="{Binding GenerateMkvpropeditArguments}"/>
+            </Grid>
+        </StackPanel>
     </Grid>
 </Page>

--- a/src/MatroskaBatchFlow.Uno/Presentation/MainViewModel.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/MainViewModel.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
+using MatroskaBatchFlow.Core.Enums;
 using MatroskaBatchFlow.Core.Services;
+using MatroskaBatchFlow.Core.Services.Builders.MkvPropeditArguments;
 
 namespace MatroskaBatchFlow.Uno.Presentation;
 
@@ -10,12 +12,18 @@ public partial class MainViewModel : ObservableObject
 
     private readonly IFileScanner _fileScanner;
 
+    private readonly IBatchConfiguration _batchConfiguration;
+
     public ICommand ScanFiles { get; }
 
-    public MainViewModel(IFileScanner fileScanner)
+    public ICommand GenerateMkvpropeditArguments { get; }
+
+    public MainViewModel(IFileScanner fileScanner, IBatchConfiguration batchConfiguration)
     {
         _fileScanner = fileScanner;
+        _batchConfiguration = batchConfiguration;
         ScanFiles = new AsyncRelayCommand(ScanFilesAsync);
+        GenerateMkvpropeditArguments = new RelayCommand(GenerateMkvpropeditArgumentsCommand);
     }
 
     private async Task ScanFilesAsync()
@@ -33,5 +41,53 @@ public partial class MainViewModel : ObservableObject
         {
             WriteIndented = true // For pretty-printing
         });
+    }
+
+    private void GenerateMkvpropeditArgumentsCommand()
+    {
+        var results = new List<string>();
+
+        foreach (var file in _batchConfiguration.FileList)
+        {
+            var builder = new MkvPropeditArgumentsBuilder()
+                .SetInputFile(file.Path)
+                .WithTitle(_batchConfiguration.Title);
+
+            // Add all tracks to the builder.
+            AddTracksToBuilder(builder, _batchConfiguration.AudioTracks, TrackType.Audio);
+            AddTracksToBuilder(builder, _batchConfiguration.VideoTracks, TrackType.Video);
+            AddTracksToBuilder(builder, _batchConfiguration.SubtitleTracks, TrackType.Text);
+
+            var args = builder.Build();
+            results.Add(string.Join(" ", args));
+        }
+
+        ScanResult = string.Join(Environment.NewLine + Environment.NewLine, results);
+    }
+
+    /// <summary>
+    /// Adds a collection of track configurations to the specified mkvpropedit arguments builder.
+    /// </summary>
+    /// <param name="builder">The builder to which the track configurations will be added.</param>
+    /// <param name="tracks">A collection of track configurations to add. Each specifies properties such as position, 
+    /// language, name, and flags.</param>
+    /// <param name="type">The type of tracks to add. Only tracks of a type that corresponds to a Matroska track element 
+    /// will be processed.</param>
+    private static void AddTracksToBuilder(IMkvPropeditArgumentsBuilder builder, IEnumerable<TrackConfiguration> tracks, TrackType type)
+    {
+        if (!type.IsMatroskaTrackElement())
+            return;
+
+        foreach (var track in tracks)
+        {
+            builder.AddTrack(t => t
+                .SetTrackId(track.Position)
+                .SetTrackType(type)
+                .WithLanguage(track.Language.Code)
+                .WithName(track.Name)
+                .WithIsDefault(track.Default)
+                .WithIsForced(track.Forced)
+            );
+        }
     }
 }


### PR DESCRIPTION
- Introduced `GetPrefix` method in `TrackTypeExtensions` for easy retrieval of track type prefixes.
- Added `FileList` property in `BatchConfiguration` for access to the scanned files.
- Updated `IBatchConfiguration` interface to include `FileList`.
- Modified `InputViewModel` to utilize `FileList` from `IBatchConfiguration`.
- Added mkvpropedit button in `MainPage.xaml`  to generate mkvpropedit arguments.
- Added `GenerateMkvpropeditArguments` command in `MainViewModel` to construct mkvpropedit arguments.
- Implemented fluent api builders for generating mkvpropedit arguments.

These changes have mainly to do with the introduction of the mkvpropedit argument generation. More work needs to be done in the implementation department as well as in testing the code.