### PR TITLE
Implemented first track selection

### DIFF
--- a/src/MatroskaBatchFlow.Uno/Presentation/AudioViewModel.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/AudioViewModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using MatroskaBatchFlow.Core.Services;
 
 namespace MatroskaBatchFlow.Uno.Presentation;
+
 public partial class AudioViewModel : TrackViewModelBase
 {
     public ObservableCollection<TrackConfiguration> AudioTracks
@@ -29,6 +30,8 @@ public partial class AudioViewModel : TrackViewModelBase
         : base(languageProvider, batchConfiguration)
     {
         AudioTracks = [.. _batchConfiguration.AudioTracks];
+
+        SelectedTrack = AudioTracks.FirstOrDefault();
 
         SetupEventHandlers();
     }
@@ -89,6 +92,7 @@ public partial class AudioViewModel : TrackViewModelBase
         }
 
         AudioTracks = [.. _batchConfiguration.AudioTracks];
+        SelectedTrack = AudioTracks.FirstOrDefault();
     }
 
     /// <inheritdoc />

--- a/src/MatroskaBatchFlow.Uno/Presentation/SubtitleViewModel.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/SubtitleViewModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using MatroskaBatchFlow.Core.Services;
 
 namespace MatroskaBatchFlow.Uno.Presentation;
+
 public partial class SubtitleViewModel : TrackViewModelBase
 {
     public ObservableCollection<TrackConfiguration> SubtitleTracks
@@ -29,6 +30,8 @@ public partial class SubtitleViewModel : TrackViewModelBase
         : base(languageProvider, batchConfiguration)
     {
         SubtitleTracks = [.. _batchConfiguration.SubtitleTracks];
+
+        SelectedTrack = SubtitleTracks.FirstOrDefault();
 
         SetupEventHandlers();
     }
@@ -91,6 +94,7 @@ public partial class SubtitleViewModel : TrackViewModelBase
         }
 
         SubtitleTracks = [.. _batchConfiguration.SubtitleTracks];
+        SelectedTrack = SubtitleTracks.FirstOrDefault();
     }
 
     /// <inheritdoc />

--- a/src/MatroskaBatchFlow.Uno/Presentation/VideoViewModel.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/VideoViewModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using MatroskaBatchFlow.Core.Services;
 
 namespace MatroskaBatchFlow.Uno.Presentation;
+
 public partial class VideoViewModel : TrackViewModelBase
 {
     public ObservableCollection<TrackConfiguration> VideoTracks
@@ -29,6 +30,8 @@ public partial class VideoViewModel : TrackViewModelBase
         : base(languageProvider, batchConfiguration)
     {
         VideoTracks = [.. _batchConfiguration.VideoTracks];
+
+        SelectedTrack = VideoTracks.FirstOrDefault();
 
         SetupEventHandlers();
     }
@@ -91,6 +94,7 @@ public partial class VideoViewModel : TrackViewModelBase
         }
 
         VideoTracks = [.. _batchConfiguration.VideoTracks];
+        SelectedTrack = VideoTracks.FirstOrDefault();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
On update of a track type collection and on initialization of their respective viewmodels, the first track in the collection will be set as selected track.

Resolves #9