### PR TITLE
refactor(core): improve native mediainfo library loading logic

### DIFF
--- a/src/MatroskaBatchFlow.Core/Utilities/MediaInfoLib/MediaInfoNativeLoader.cs
+++ b/src/MatroskaBatchFlow.Core/Utilities/MediaInfoLib/MediaInfoNativeLoader.cs
@@ -34,23 +34,35 @@ public static class MediaInfoNativeLoader
     /// cref="IntPtr.Zero"/>.</returns>
     private static IntPtr ResolveMediaInfoLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
     {
-        string? path = null;
+        string? fileName = null;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            path = "Binaries/MediaInfo.dll";
+            fileName = "MediaInfo.dll";
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            path = "Binaries/libmediainfo.so";
+            fileName = "libmediainfo.so";
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            path = "Binaries/libmediainfo.so";
+            fileName = "libmediainfo.so";
         }
 
-        if (path is not null && NativeLibrary.TryLoad(path, out var handle))
+        if (fileName is not null)
         {
-            return handle;
+            // Try loading from Binaries subdirectory (standard location)
+            string path = Path.Combine(AppContext.BaseDirectory, "Binaries", fileName);
+            if (NativeLibrary.TryLoad(path, out var handle))
+            {
+                return handle;
+            }
+
+            // Fallback: try same directory as the application
+            path = Path.Combine(AppContext.BaseDirectory, fileName);
+            if (NativeLibrary.TryLoad(path, out var fallbackHandle))
+            {
+                return fallbackHandle;
+            }
         }
 
         return IntPtr.Zero; // fallback to default


### PR DESCRIPTION
This pull request refines the logic for resolving and loading the MediaInfo native library in `MediaInfoNativeLoader.cs`. The update improves the robustness of library loading by introducing a fallback mechanism if the library is not found in the expected subdirectory.

Improvements to MediaInfo library loading:

* The `ResolveMediaInfoLibrary` method now first attempts to load the MediaInfo library from the `Binaries` subdirectory, and if that fails, tries to load it from the application's base directory as a fallback.
* The variable `path` has been renamed to `fileName` to clarify its purpose, and path construction now uses `Path.Combine` for better cross-platform compatibility.