### PR TITLE
feat(dev): add WinAppSDK debug launch config for VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,5 +24,20 @@
       "console": "internalConsole",
       "stopAtEntry": false
     },
+    {
+      "name": "Uno Platform WinAppSDK Debug",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-winappsdk",
+      "program": "${workspaceFolder}/src/MatroskaBatchFlow.Uno/bin/Debug/net10.0-windows10.0.19041/MatroskaBatchFlow.exe",
+      "args": [],
+      "launchSettingsProfile": "MatroskaBatchFlow.Uno (WinAppSDK Unpackaged)",
+      "env": {
+        "DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
+      },
+      "cwd": "${workspaceFolder}/src/MatroskaBatchFlow.Uno",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    }
   ]
 }


### PR DESCRIPTION
- Add "Uno Platform WinAppSDK Debug" launch configuration to launch.json for VS Code
- Enable debugging in VS Code of MatroskaBatchFlow.Uno with WinAppSDK in unpackaged mode