### PR TITLE
feat(ui): make copyright notice dynamic in About section

### DIFF
--- a/src/MatroskaBatchFlow.Uno/Presentation/SettingsPage.xaml
+++ b/src/MatroskaBatchFlow.Uno/Presentation/SettingsPage.xaml
@@ -365,7 +365,7 @@
                            Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"/>
 
                 <controls:SettingsExpander Header="Matroska Batch Flow"
-                                   Description="© 2025. All rights reserved."
+                                   Description="{x:Bind CopyrightNotice}"
                                    IsExpanded="True">
                     <controls:SettingsExpander.HeaderIcon>
                         <BitmapIcon ShowAsMonochrome="False"

--- a/src/MatroskaBatchFlow.Uno/Presentation/SettingsPage.xaml.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/SettingsPage.xaml.cs
@@ -16,6 +16,10 @@ public sealed partial class SettingsPage : Page
     [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "Suppression is necessary.")]
     public string AppVersion => $"Version {AppEnvironmentHelper.GetApplicationVersion().ToString(3)}";
 
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Binding requires instance member.")]
+    [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "Suppression is necessary.")]
+    public string CopyrightNotice => $"© 2025-{DateTime.Now.Year}. All rights reserved.";
+
     public SettingsPage()
     {
         this.InitializeComponent();


### PR DESCRIPTION
This pull request updates the copyright notice in the Settings page to dynamically display the current year and makes the notice accessible for UI data binding.

UI improvements:

* Changed the `Description` property of the `SettingsExpander` in `SettingsPage.xaml` to bind to a new property instead of using a hardcoded string.

Code enhancements for data binding:

* Added a `CopyrightNotice` property to the `SettingsPage` class in `SettingsPage.xaml.cs`, which generates a copyright string with the current year and is suitable for binding in the UI.