### PR TITLE
chore(ci): remove redundant build-status job

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -127,26 +127,3 @@ jobs:
         path: 'test-results/**/*.trx'
         reporter: dotnet-trx
         fail-on-error: true
-
-  build-status:
-    name: Build Status Check
-    runs-on: windows-latest
-    needs: [build, test, test-summary]
-    if: always()
-    
-    steps:
-    - name: Check build status
-      run: |
-        if ("${{ needs.build.result }}" -ne "success") {
-          Write-Error "Build job failed"
-          exit 1
-        }
-        if ("${{ needs.test.result }}" -ne "success") {
-          Write-Error "Test job failed"
-          exit 1
-        }
-        if ("${{ needs.test-summary.result }}" -ne "success" -and "${{ needs.test-summary.result }}" -ne "skipped") {
-          Write-Error "Test summary job failed"
-          exit 1
-        }
-        Write-Host "✅ All checks passed!"


### PR DESCRIPTION
This pull request removes the `build-status` job from the `.github/workflows/pr-build-test.yml` workflow file. The `build-status` job previously checked the results of the build, test, and test-summary jobs to ensure all steps completed successfully.

Workflow simplification:

* Removed the `build-status` job, including its status checks and error handling logic, from the `.github/workflows/pr-build-test.yml` file.