### PR TITLE
chore(deps): update Uno.Sdk and Microsoft.Extensions packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,16 +7,16 @@
   -->
   <ItemGroup>
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.251219" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.2" />
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.251219" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.0-dev.100"
+    "Uno.Sdk": "6.5.31"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
- Update Uno.Sdk from 6.5.0-dev.100 to 6.5.31
- Update Microsoft.Extensions.Configuration from 10.0.1 to 10.0.2
- Update Microsoft.Extensions.Configuration.Abstractions from 10.0.1 to 10.0.2
- Update Microsoft.Extensions.Logging.Abstractions from 10.0.1 to 10.0.2
- Update Microsoft.Extensions.Options from 10.0.1 to 10.0.2
- Update Microsoft.Extensions.Options.DataAnnotations from 10.0.1 to 10.0.2