### PR TITLE
chore(version): bump application version to 0.9.0

### DIFF
--- a/src/MatroskaBatchFlow.Uno/MatroskaBatchFlow.Uno.csproj
+++ b/src/MatroskaBatchFlow.Uno/MatroskaBatchFlow.Uno.csproj
@@ -55,7 +55,7 @@
         <PackageCertificateKeyFile>MatroskaBatchFlow.Uno_TemporaryKey.pfx</PackageCertificateKeyFile>
         <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
         <PublishAot>False</PublishAot>
-        <AssemblyVersion>0.8.0.0</AssemblyVersion>
+        <AssemblyVersion>0.9.0.0</AssemblyVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" />

--- a/src/MatroskaBatchFlow.Uno/Package.appxmanifest
+++ b/src/MatroskaBatchFlow.Uno/Package.appxmanifest
@@ -5,7 +5,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity  Name="MatroskaBatchFlow"  Version="0.8.0.0" Publisher="CN=Tim"/>
+  <Identity  Name="MatroskaBatchFlow"  Version="0.9.0.0" Publisher="CN=Tim"/>
   <Properties >
   
   <DisplayName>Matroska Batch Flow</DisplayName>


### PR DESCRIPTION
This pull request updates the version of the MatroskaBatchFlow.Uno application from 0.8.0 to 0.9.0 in both the project and manifest files.

- Version bump:
  * Updated the `AssemblyVersion` in `MatroskaBatchFlow.Uno.csproj` from 0.8.0.0 to 0.9.0.0.
  * Updated the `Version` in `Package.appxmanifest` from 0.8.0.0 to 0.9.0.0.