### PR TITLE
Add workflow to notify website on new release

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -1,0 +1,17 @@
+name: Notify website of new release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger website version update
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/TimGels/matroskabatchflow.com/dispatches \
+            --method POST \
+            -f event_type=release-published


### PR DESCRIPTION
Implement a CI workflow that triggers a notification to the website whenever a new release is published. This is needed to have the website repo side change the version on the hero section.