### PR TITLE
Fix file processing issue for newly added tracks

### DIFF
--- a/src/MatroskaBatchFlow.Core/Models/FileTrackConfiguration.cs
+++ b/src/MatroskaBatchFlow.Core/Models/FileTrackConfiguration.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using MatroskaBatchFlow.Core.Enums;
-using MatroskaBatchFlow.Core.Services;
 
 namespace MatroskaBatchFlow.Core.Models;
 
@@ -15,26 +14,26 @@ public sealed class FileTrackConfiguration
     public string FilePath { get; set; } = string.Empty;
 
     /// <summary>
-    /// Audio track configurations for this file.
+    /// Audio track values for this file.
     /// </summary>
-    public ObservableCollection<TrackConfiguration> AudioTracks { get; set; } = [];
+    public ObservableCollection<FileTrackValues> AudioTracks { get; set; } = [];
 
     /// <summary>
-    /// Video track configurations for this file.
+    /// Video track values for this file.
     /// </summary>
-    public ObservableCollection<TrackConfiguration> VideoTracks { get; set; } = [];
+    public ObservableCollection<FileTrackValues> VideoTracks { get; set; } = [];
 
     /// <summary>
-    /// Subtitle track configurations for this file.
+    /// Subtitle track values for this file.
     /// </summary>
-    public ObservableCollection<TrackConfiguration> SubtitleTracks { get; set; } = [];
+    public ObservableCollection<FileTrackValues> SubtitleTracks { get; set; } = [];
 
     /// <summary>
     /// Gets the track list for a specific track type.
     /// </summary>
     /// <param name="trackType">The track type to retrieve.</param>
-    /// <returns>Observable collection of track configurations for the specified type.</returns>
-    public ObservableCollection<TrackConfiguration> GetTrackListForType(TrackType trackType)
+    /// <returns>Observable collection of track values for the specified type.</returns>
+    public ObservableCollection<FileTrackValues> GetTrackListForType(TrackType trackType)
     {
         return trackType switch
         {

--- a/src/MatroskaBatchFlow.Core/Models/FileTrackValues.cs
+++ b/src/MatroskaBatchFlow.Core/Models/FileTrackValues.cs
@@ -3,8 +3,7 @@ using MatroskaBatchFlow.Core.Enums;
 namespace MatroskaBatchFlow.Core.Models;
 
 /// <summary>
-/// Stores per-file track values that are initially populated from the MediaInfo scan and
-/// subsequently updated when the user changes settings in the UI.
+/// Stores per-file track values that are initially populated from the MediaInfo scan.
 /// The original scanned data is always available via <see cref="ScannedTrackInfo"/>.
 /// </summary>
 /// <remarks>
@@ -12,15 +11,18 @@ namespace MatroskaBatchFlow.Core.Models;
 /// <list type="bullet">
 /// <item>
 /// <see cref="Services.TrackConfiguration"/> - one per track index in the global collection.
-/// Carries modification intent (<c>ShouldModify*</c> flags) and is shared across all files.
+/// Carries modification intent (<c>ShouldModify*</c> flags) and the effective values
+/// (Name, Language, flags) that should be written, and is shared across all files.
 /// </item>
 /// <item>
 /// <see cref="FileTrackValues"/> - one per track per file in <see cref="FileTrackConfiguration"/>.
-/// Holds the actual values (Name, Language, flags) to write for that specific file.
+/// Represents the scanned/current per-file values and indicates whether a given file actually
+/// has a track at a particular index.
 /// </item>
 /// </list>
-/// During command generation, <see cref="Services.MkvPropeditArgumentsGenerator"/> reads
-/// <c>ShouldModify*</c> from the global track and the values to write from the per-file track.
+/// During command generation, <see cref="Services.MkvPropeditArgumentsGenerator"/> reads both
+/// <c>ShouldModify*</c> and the values to write from the global track configuration, and uses
+/// <see cref="FileTrackValues"/> only to determine per-file track existence and indexing.
 /// </remarks>
 public sealed class FileTrackValues
 {

--- a/src/MatroskaBatchFlow.Core/Models/FileTrackValues.cs
+++ b/src/MatroskaBatchFlow.Core/Models/FileTrackValues.cs
@@ -1,0 +1,66 @@
+using MatroskaBatchFlow.Core.Enums;
+
+namespace MatroskaBatchFlow.Core.Models;
+
+/// <summary>
+/// Stores per-file track values that are initially populated from the MediaInfo scan and
+/// subsequently updated when the user changes settings in the UI.
+/// The original scanned data is always available via <see cref="ScannedTrackInfo"/>.
+/// </summary>
+/// <remarks>
+/// The batch configuration uses a dual-model approach for tracks:
+/// <list type="bullet">
+/// <item>
+/// <see cref="Services.TrackConfiguration"/> - one per track index in the global collection.
+/// Carries modification intent (<c>ShouldModify*</c> flags) and is shared across all files.
+/// </item>
+/// <item>
+/// <see cref="FileTrackValues"/> - one per track per file in <see cref="FileTrackConfiguration"/>.
+/// Holds the actual values (Name, Language, flags) to write for that specific file.
+/// </item>
+/// </list>
+/// During command generation, <see cref="Services.MkvPropeditArgumentsGenerator"/> reads
+/// <c>ShouldModify*</c> from the global track and the values to write from the per-file track.
+/// </remarks>
+public sealed class FileTrackValues
+{
+    /// <summary>
+    /// The raw track information as returned by MediaInfo.
+    /// </summary>
+    public required MediaInfoResult.MediaInfo.TrackInfo ScannedTrackInfo { get; init; }
+
+    /// <summary>
+    /// The type of this track (Audio, Video, Text).
+    /// </summary>
+    public TrackType Type { get; init; }
+
+    /// <summary>
+    /// Zero-based index of this track within its type (e.g. 0 = first audio track).
+    /// </summary>
+    public int Index { get; init; }
+
+    /// <summary>
+    /// The track name as scanned from the file.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The track language as scanned from the file.
+    /// </summary>
+    public MatroskaLanguageOption Language { get; set; } = MatroskaLanguageOption.Undetermined;
+
+    /// <summary>
+    /// Whether this track has the default flag set.
+    /// </summary>
+    public bool Default { get; set; }
+
+    /// <summary>
+    /// Whether this track has the forced flag set.
+    /// </summary>
+    public bool Forced { get; set; }
+
+    /// <summary>
+    /// Whether this track is enabled (corresponds to the Matroska FlagEnabled element).
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/src/MatroskaBatchFlow.Core/Services/BatchConfiguration.cs
+++ b/src/MatroskaBatchFlow.Core/Services/BatchConfiguration.cs
@@ -321,7 +321,7 @@ public partial class BatchConfiguration : IBatchConfiguration
 
     /// <inheritdoc />
     /// <exception cref="InvalidOperationException">Thrown if no per-file track configuration exists for the specified file ID.</exception>
-    public IList<TrackConfiguration> GetTrackListForFile(Guid fileId, TrackType trackType)
+    public IList<FileTrackValues> GetTrackListForFile(Guid fileId, TrackType trackType)
     {
         // Prefer per-file configuration. If none exists, fail fast by throwing an exception.
         if (FileConfigurations.TryGetValue(fileId, out var fileConfig))
@@ -656,7 +656,7 @@ public sealed class TrackConfiguration(TrackInfo trackInfo) : INotifyPropertyCha
         }
     }
 
-    protected void OnPropertyChanged(string propertyName)
+    private void OnPropertyChanged(string propertyName)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }

--- a/src/MatroskaBatchFlow.Core/Services/BatchTrackConfigurationInitializer.cs
+++ b/src/MatroskaBatchFlow.Core/Services/BatchTrackConfigurationInitializer.cs
@@ -7,15 +7,15 @@ namespace MatroskaBatchFlow.Core.Services;
 /// Initializes per-file track configurations based on scanned file information.
 /// </summary>
 /// <remarks>
-/// This class orchestrates the creation of individual track configurations for each file:
+/// This class orchestrates track initialization for each file:
 /// <list type="bullet">
-/// <item>Delegates track configuration creation to <see cref="ITrackConfigurationFactory"/></item>
+/// <item>Creates per-file <see cref="FileTrackValues"/> directly from scanned track metadata</item>
+/// <item>Delegates global <see cref="TrackConfiguration"/> creation to <see cref="ITrackConfigurationFactory"/> when expanding to match maximum track counts</item>
 /// <item>Populates file-specific track lists in <see cref="IBatchConfiguration.FileConfigurations"/></item>
-/// <item>Updates global track collections to reflect maximum track counts for UI display</item>
 /// </list>
 /// </remarks>
 /// <param name="batchConfig">The batch configuration to be modified.</param>
-/// <param name="trackConfigFactory">The factory for creating track configurations.</param>
+/// <param name="trackConfigFactory">The factory for creating global track configurations.</param>
 /// <param name="languageProvider">The language provider for resolving track language codes.</param>
 public class BatchTrackConfigurationInitializer(
     IBatchConfiguration batchConfig,

--- a/src/MatroskaBatchFlow.Core/Services/BatchTrackConfigurationInitializer.cs
+++ b/src/MatroskaBatchFlow.Core/Services/BatchTrackConfigurationInitializer.cs
@@ -16,9 +16,11 @@ namespace MatroskaBatchFlow.Core.Services;
 /// </remarks>
 /// <param name="batchConfig">The batch configuration to be modified.</param>
 /// <param name="trackConfigFactory">The factory for creating track configurations.</param>
+/// <param name="languageProvider">The language provider for resolving track language codes.</param>
 public class BatchTrackConfigurationInitializer(
     IBatchConfiguration batchConfig,
-    ITrackConfigurationFactory trackConfigFactory) : IBatchTrackConfigurationInitializer
+    ITrackConfigurationFactory trackConfigFactory,
+    ILanguageProvider languageProvider) : IBatchTrackConfigurationInitializer
 {
     /// <inheritdoc/>
     public void Initialize(ScannedFileInfo scannedFile, params TrackType[] trackTypes)
@@ -36,7 +38,7 @@ public class BatchTrackConfigurationInitializer(
             batchConfig.FileConfigurations.Add(scannedFile.Id, fileConfig);
         }
 
-        // Populate file-specific track configurations based on what this file has
+        // Populate file-specific track values based on what this file has
         foreach (var trackType in trackTypes)
         {
             // Ordering tracks by StreamKindID as it represents the track order in the file
@@ -52,7 +54,17 @@ public class BatchTrackConfigurationInitializer(
 
             for (int i = existingCount; i < scannedCount; i++)
             {
-                fileTracks.Add(trackConfigFactory.Create(scannedTracks[i], trackType, i));
+                var scannedTrack = scannedTracks[i];
+                fileTracks.Add(new FileTrackValues
+                {
+                    ScannedTrackInfo = scannedTrack,
+                    Type = trackType,
+                    Index = i,
+                    Name = scannedTrack.Title ?? string.Empty,
+                    Language = languageProvider.Resolve(scannedTrack.Language),
+                    Default = scannedTrack.Default,
+                    Forced = scannedTrack.Forced,
+                });
             }
         }
 

--- a/src/MatroskaBatchFlow.Core/Services/IBatchConfiguration.cs
+++ b/src/MatroskaBatchFlow.Core/Services/IBatchConfiguration.cs
@@ -9,8 +9,9 @@ namespace MatroskaBatchFlow.Core.Services;
 /// <summary>
 /// Defines the contract for batch configuration of media files.
 /// <br />
-/// Note: The TrackConfiguration items in the collections also implement INotifyPropertyChanged,
-/// so property changes within tracks can be observed.
+/// Note: The TrackConfiguration items in the global collections implement INotifyPropertyChanged,
+/// so property changes within global tracks can be observed.
+/// Per-file track values are stored as <see cref="FileTrackValues"/> which carry no modification intent.
 /// </summary>
 public interface IBatchConfiguration : INotifyPropertyChanged
 {
@@ -51,13 +52,14 @@ public interface IBatchConfiguration : INotifyPropertyChanged
     public IList<TrackConfiguration> GetTrackListForType(TrackType trackType);
 
     /// <summary>
-    /// Gets track configuration for a specific file and track type.
-    /// Always uses per-file configurations. Falls back to global if file config not found.
+    /// Gets the per-file track values for a specific file and track type.
+    /// These carry only scanned values (Name, Language, flags) — no modification intent.
+    /// Modification flags (<c>ShouldModify*</c>) live on the global <see cref="TrackConfiguration"/> objects returned by <see cref="GetTrackListForType"/>.
     /// </summary>
     /// <param name="fileId">The ScannedFileInfo.Id (Guid) of the file.</param>
     /// <param name="trackType">Type of track to retrieve.</param>
-    /// <returns>List of track configurations for the specified file and track type.</returns>
-    public IList<TrackConfiguration> GetTrackListForFile(Guid fileId, TrackType trackType);
+    /// <returns>List of per-file track values for the specified file and track type.</returns>
+    public IList<FileTrackValues> GetTrackListForFile(Guid fileId, TrackType trackType);
 
     /// <summary>
     /// Migrates file configuration from an old file ID to a new file ID.

--- a/src/MatroskaBatchFlow.Core/Services/ILanguageProvider.cs
+++ b/src/MatroskaBatchFlow.Core/Services/ILanguageProvider.cs
@@ -8,4 +8,11 @@ public interface ILanguageProvider
     public ImmutableList<MatroskaLanguageOption> Languages { get; }
 
     public void LoadLanguages();
+
+    /// <summary>
+    /// Resolves a raw language string from MediaInfo into a typed <see cref="MatroskaLanguageOption"/>.
+    /// </summary>
+    /// <param name="languageCode">The language code (e.g., "en", "eng", or "English").</param>
+    /// <returns>The matching language option, or <see cref="MatroskaLanguageOption.Undetermined"/> if no match found.</returns>
+    MatroskaLanguageOption Resolve(string? languageCode);
 }

--- a/src/MatroskaBatchFlow.Core/Services/LanguageProvider.cs
+++ b/src/MatroskaBatchFlow.Core/Services/LanguageProvider.cs
@@ -66,4 +66,21 @@ public partial class LanguageProvider : ILanguageProvider
             Languages = [];
         }
     }
+
+    /// <inheritdoc/>
+    public MatroskaLanguageOption Resolve(string? languageCode)
+    {
+        if (string.IsNullOrWhiteSpace(languageCode))
+            return MatroskaLanguageOption.Undetermined;
+
+        var matchedLanguage = Languages.FirstOrDefault(lang =>
+            string.Equals(lang.Iso639_2_b, languageCode, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(lang.Iso639_2_t, languageCode, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(lang.Iso639_1, languageCode, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(lang.Iso639_3, languageCode, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(lang.Name, languageCode, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(lang.Code, languageCode, StringComparison.OrdinalIgnoreCase));
+
+        return matchedLanguage ?? MatroskaLanguageOption.Undetermined;
+    }
 }

--- a/src/MatroskaBatchFlow.Core/Services/MkvPropeditArgumentsGenerator.Logging.cs
+++ b/src/MatroskaBatchFlow.Core/Services/MkvPropeditArgumentsGenerator.Logging.cs
@@ -1,0 +1,14 @@
+using MatroskaBatchFlow.Core.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace MatroskaBatchFlow.Core.Services;
+
+/// <summary>
+/// LoggerMessage definitions for <see cref="MkvPropeditArgumentsGenerator"/>.
+/// </summary>
+public sealed partial class MkvPropeditArgumentsGenerator
+{
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Per-file {TrackType} track index {TrackIndex} exceeds global track count {GlobalTrackCount} for file: {FilePath}")]
+    private partial void LogPerFileTrackExceedsGlobalCount(string filePath, TrackType trackType, int trackIndex, int globalTrackCount);
+}

--- a/src/MatroskaBatchFlow.Core/Services/MkvPropeditArgumentsGenerator.cs
+++ b/src/MatroskaBatchFlow.Core/Services/MkvPropeditArgumentsGenerator.cs
@@ -1,13 +1,14 @@
 using MatroskaBatchFlow.Core.Builders.MkvPropeditArguments;
 using MatroskaBatchFlow.Core.Enums;
 using MatroskaBatchFlow.Core.Models;
+using Microsoft.Extensions.Logging;
 
 namespace MatroskaBatchFlow.Core.Services;
 
 /// <summary>
 /// Provides reusable logic for generating <c>mkvpropedit</c> command-line arguments from an <see cref="IBatchConfiguration"/>.
 /// </summary>
-public sealed class MkvPropeditArgumentsGenerator : IMkvPropeditArgumentsGenerator
+public sealed partial class MkvPropeditArgumentsGenerator(ILogger<MkvPropeditArgumentsGenerator> logger) : IMkvPropeditArgumentsGenerator
 {
     /// <inheritdoc />
     public string[] BuildBatchArguments(IBatchConfiguration batchConfiguration)
@@ -42,7 +43,7 @@ public sealed class MkvPropeditArgumentsGenerator : IMkvPropeditArgumentsGenerat
     /// <param name="batchConfiguration">Contains global title settings and per-file track configurations.</param>
     /// <returns> Token array suitable for joining. Returns an empty array if no modifications are requested 
     /// (to signal "no-op").</returns>
-    private static string[] BuildFileArgumentTokens(ScannedFileInfo file, IBatchConfiguration batchConfiguration)
+    private string[] BuildFileArgumentTokens(ScannedFileInfo file, IBatchConfiguration batchConfiguration)
     {
         var builder = new MkvPropeditArgumentsBuilder();
 
@@ -84,11 +85,17 @@ public sealed class MkvPropeditArgumentsGenerator : IMkvPropeditArgumentsGenerat
     /// Adds track-specific modifications to the builder for a specific file, filtering out tracks that have
     /// no requested changes or don't exist in the file.
     /// </summary>
+    /// <remarks>
+    /// Modification intent (<c>ShouldModify*</c>) is read from the global <see cref="TrackConfiguration"/> at
+    /// the matching index. The actual values to write (Name, Language, flags) are read from the per-file
+    /// <see cref="FileTrackValues"/>, which are initially populated from the MediaInfo scan and subsequently
+    /// updated when the user changes settings in the UI.
+    /// </remarks>
     /// <param name="builder">The accumulating mkvpropedit argument builder.</param>
     /// <param name="file">The file being processed.</param>
     /// <param name="type">The track type (must map to a Matroska track element).</param>
     /// <param name="batchConfig">The batch configuration containing track availability data.</param>
-    private static void AddTracksForFile(
+    private void AddTracksForFile(
         MkvPropeditArgumentsBuilder builder,
         ScannedFileInfo file,
         TrackType type,
@@ -99,17 +106,30 @@ public sealed class MkvPropeditArgumentsGenerator : IMkvPropeditArgumentsGenerat
             return;
         }
 
-        // Get file-specific track configuration.
-        var tracks = batchConfig.GetTrackListForFile(file.Id, type);
+        // Per-file values (Name, Language, flags as scanned from this file).
+        var perFileTracks = batchConfig.GetTrackListForFile(file.Id, type);
 
-        foreach (var track in tracks)
+        // Global tracks carry the modification intent (ShouldModify* flags).
+        var globalTracks = batchConfig.GetTrackListForType(type);
+
+        foreach (var track in perFileTracks)
         {
+            // Defensive: the initializer always expands global tracks to the maximum
+            // count, so this should not be true under normal operation.
+            if (track.Index >= globalTracks.Count)
+            {
+                LogPerFileTrackExceedsGlobalCount(file.Path, type, track.Index, globalTracks.Count);
+                continue;
+            }
+
+            var globalTrack = globalTracks[track.Index];
+
             // Skip inert tracks (no requested modifications).
-            if (!(track.ShouldModifyLanguage ||
-                  track.ShouldModifyName ||
-                  track.ShouldModifyDefaultFlag ||
-                  track.ShouldModifyForcedFlag ||
-                  track.ShouldModifyEnabledFlag))
+            if (!(globalTrack.ShouldModifyLanguage ||
+                  globalTrack.ShouldModifyName ||
+                  globalTrack.ShouldModifyDefaultFlag ||
+                  globalTrack.ShouldModifyForcedFlag ||
+                  globalTrack.ShouldModifyEnabledFlag))
             {
                 continue;
             }
@@ -126,27 +146,27 @@ public sealed class MkvPropeditArgumentsGenerator : IMkvPropeditArgumentsGenerat
                 // Track ID converted to 1-based indexing for mkvpropedit conventions.
                 tb.SetTrackId(track.Index + 1).SetTrackType(type);
 
-                if (track.ShouldModifyLanguage)
+                if (globalTrack.ShouldModifyLanguage)
                 {
                     tb.WithLanguage(track.Language.Code);
                 }
 
-                if (track.ShouldModifyName)
+                if (globalTrack.ShouldModifyName)
                 {
                     tb.WithName(track.Name);
                 }
 
-                if (track.ShouldModifyDefaultFlag)
+                if (globalTrack.ShouldModifyDefaultFlag)
                 {
                     tb.WithIsDefault(track.Default);
                 }
 
-                if (track.ShouldModifyForcedFlag)
+                if (globalTrack.ShouldModifyForcedFlag)
                 {
                     tb.WithIsForced(track.Forced);
                 }
 
-                if (track.ShouldModifyEnabledFlag)
+                if (globalTrack.ShouldModifyEnabledFlag)
                 {
                     tb.WithIsEnabled(track.Enabled);
                 }

--- a/src/MatroskaBatchFlow.Core/Services/MkvPropeditArgumentsGenerator.cs
+++ b/src/MatroskaBatchFlow.Core/Services/MkvPropeditArgumentsGenerator.cs
@@ -86,10 +86,9 @@ public sealed partial class MkvPropeditArgumentsGenerator(ILogger<MkvPropeditArg
     /// no requested changes or don't exist in the file.
     /// </summary>
     /// <remarks>
-    /// Modification intent (<c>ShouldModify*</c>) is read from the global <see cref="TrackConfiguration"/> at
-    /// the matching index. The actual values to write (Name, Language, flags) are read from the per-file
-    /// <see cref="FileTrackValues"/>, which are initially populated from the MediaInfo scan and subsequently
-    /// updated when the user changes settings in the UI.
+    /// Both the modification intent (<c>ShouldModify*</c>) and the actual values to write (Name, Language,
+    /// flags) are read from the global <see cref="TrackConfiguration"/> at the matching index. Per-file
+    /// <see cref="FileTrackValues"/> are used only to determine which tracks exist in each file.
     /// </remarks>
     /// <param name="builder">The accumulating mkvpropedit argument builder.</param>
     /// <param name="file">The file being processed.</param>
@@ -148,27 +147,27 @@ public sealed partial class MkvPropeditArgumentsGenerator(ILogger<MkvPropeditArg
 
                 if (globalTrack.ShouldModifyLanguage)
                 {
-                    tb.WithLanguage(track.Language.Code);
+                    tb.WithLanguage(globalTrack.Language.Code);
                 }
 
                 if (globalTrack.ShouldModifyName)
                 {
-                    tb.WithName(track.Name);
+                    tb.WithName(globalTrack.Name);
                 }
 
                 if (globalTrack.ShouldModifyDefaultFlag)
                 {
-                    tb.WithIsDefault(track.Default);
+                    tb.WithIsDefault(globalTrack.Default);
                 }
 
                 if (globalTrack.ShouldModifyForcedFlag)
                 {
-                    tb.WithIsForced(track.Forced);
+                    tb.WithIsForced(globalTrack.Forced);
                 }
 
                 if (globalTrack.ShouldModifyEnabledFlag)
                 {
-                    tb.WithIsEnabled(track.Enabled);
+                    tb.WithIsEnabled(globalTrack.Enabled);
                 }
 
                 return tb;

--- a/src/MatroskaBatchFlow.Core/Services/TrackConfigurationFactory.cs
+++ b/src/MatroskaBatchFlow.Core/Services/TrackConfigurationFactory.cs
@@ -22,34 +22,9 @@ public class TrackConfigurationFactory(ILanguageProvider languageProvider) : ITr
             Type = trackType,
             Index = index,
             Name = scannedTrackInfo.Title ?? string.Empty,
-            Language = ParseLanguageFromCode(scannedTrackInfo.Language),
+            Language = languageProvider.Resolve(scannedTrackInfo.Language),
             Default = scannedTrackInfo.Default,
             Forced = scannedTrackInfo.Forced
         };
-    }
-
-    /// <summary>
-    /// Parses a language code from scanned track info and returns the matching <see cref="MatroskaLanguageOption"/>.
-    /// </summary>
-    /// <remarks>
-    /// Performs case-insensitive comparison against ISO 639-1, ISO 639-2 (both bibliographic and terminologic),
-    /// ISO 639-3 codes, the language name, and a custom code field.
-    /// </remarks>
-    /// <param name="languageCode">The language code from MediaInfo (e.g., "en", "eng", "jpn", or "English").</param>
-    /// <returns>The matching language option, or <see cref="MatroskaLanguageOption.Undetermined"/> if no match found.</returns>
-    private MatroskaLanguageOption ParseLanguageFromCode(string? languageCode)
-    {
-        if (string.IsNullOrWhiteSpace(languageCode))
-            return MatroskaLanguageOption.Undetermined;
-
-        var matchedLanguage = languageProvider.Languages.FirstOrDefault(lang =>
-            string.Equals(lang.Iso639_2_b, languageCode, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(lang.Iso639_2_t, languageCode, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(lang.Iso639_1, languageCode, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(lang.Iso639_3, languageCode, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(lang.Name, languageCode, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(lang.Code, languageCode, StringComparison.OrdinalIgnoreCase));
-
-        return matchedLanguage ?? MatroskaLanguageOption.Undetermined;
     }
 }

--- a/src/MatroskaBatchFlow.Uno/Presentation/AudioViewModel.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/AudioViewModel.cs
@@ -28,8 +28,8 @@ public partial class AudioViewModel : TrackViewModelBase
     /// </summary>
     public bool IsFileListPopulated => _batchConfiguration.FileList.Count > 0;
 
-    public AudioViewModel(ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences)
-        : base(languageProvider, batchConfiguration, uiPreferences)
+    public AudioViewModel(ILogger<AudioViewModel> logger, ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences)
+        : base(logger, languageProvider, batchConfiguration, uiPreferences)
     {
         AudioTracks = [.. _batchConfiguration.AudioTracks];
 

--- a/src/MatroskaBatchFlow.Uno/Presentation/SubtitleViewModel.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/SubtitleViewModel.cs
@@ -28,8 +28,8 @@ public partial class SubtitleViewModel : TrackViewModelBase
     /// </summary>
     public bool IsFileListPopulated => _batchConfiguration.FileList.Count > 0;
 
-    public SubtitleViewModel(ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences)
-        : base(languageProvider, batchConfiguration, uiPreferences)
+    public SubtitleViewModel(ILogger<SubtitleViewModel> logger, ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences)
+        : base(logger, languageProvider, batchConfiguration, uiPreferences)
     {
         SubtitleTracks = [.. _batchConfiguration.SubtitleTracks];
 

--- a/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.Logging.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.Logging.cs
@@ -5,6 +5,6 @@ namespace MatroskaBatchFlow.Uno.Presentation;
 /// </summary>
 public abstract partial class TrackViewModelBase
 {
-    [LoggerMessage(Level = LogLevel.Warning, Message = "SelectedLanguage was set to null; falling back to Undetermined. This is unexpected during normal UI operation.")]
-    private partial void LogSelectedLanguageNullFallback();
+    [LoggerMessage(Level = LogLevel.Warning, Message = "SelectedLanguage was set to null; falling back to Undetermined.")]
+    private partial void LogSelectedLanguageReceivedNull();
 }

--- a/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.Logging.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.Logging.cs
@@ -1,0 +1,10 @@
+namespace MatroskaBatchFlow.Uno.Presentation;
+
+/// <summary>
+/// LoggerMessage definitions for <see cref="TrackViewModelBase"/>.
+/// </summary>
+public abstract partial class TrackViewModelBase
+{
+    [LoggerMessage(Level = LogLevel.Warning, Message = "SelectedLanguage was set to null; falling back to Undetermined. This is unexpected during normal UI operation.")]
+    private partial void LogSelectedLanguageNullFallback();
+}

--- a/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.cs
@@ -396,7 +396,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             return;
 
         // First, update all per-file value collections silently (without triggering events)
-        // This ensures command generation uses the updated values
+        // This keeps per-file configurations in sync with the global track settings used for command generation
         var trackType = SelectedTrack.Type;
         foreach (var kvp in _batchConfiguration.FileConfigurations)
         {

--- a/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.cs
@@ -187,7 +187,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
                 // During internal resets (ApplyTrackProperties), _suppressBatchConfigUpdate is true and null is expected.
                 if (value is null && !_suppressBatchConfigUpdate)
                 {
-                    LogSelectedLanguageNullFallback();
+                    LogSelectedLanguageReceivedNull();
                 }
 
                 MatroskaLanguageOption language = value ?? MatroskaLanguageOption.Undetermined;

--- a/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/TrackViewModelBase.cs
@@ -8,6 +8,7 @@ namespace MatroskaBatchFlow.Uno.Presentation;
 
 public abstract partial class TrackViewModelBase : ObservableObject
 {
+    private readonly ILogger _logger;
     protected bool _suppressBatchConfigUpdate = false;
     protected ObservableCollection<TrackConfiguration> _tracks = [];
 
@@ -53,7 +54,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _isDefaultTrack = value;
                 OnPropertyChanged(nameof(IsDefaultTrack));
-                UpdateBatchConfigTrackProperty(tc => tc.Default = value);
+                UpdateBatchConfigTrackProperty(tc => tc.Default = value, ftv => ftv.Default = value);
             }
         }
     }
@@ -69,7 +70,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _isDefaultFlagModificationEnabled = value;
                 OnPropertyChanged(nameof(IsDefaultFlagModificationEnabled));
-                UpdateBatchConfigTrackProperty(tc => tc.ShouldModifyDefaultFlag = value);
+                UpdateGlobalModificationFlag(tc => tc.ShouldModifyDefaultFlag = value);
             }
         }
     }
@@ -85,7 +86,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _isEnabledTrack = value;
                 OnPropertyChanged(nameof(IsEnabledTrack));
-                UpdateBatchConfigTrackProperty(tc => tc.Enabled = value);
+                UpdateBatchConfigTrackProperty(tc => tc.Enabled = value, ftv => ftv.Enabled = value);
             }
         }
     }
@@ -101,7 +102,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _isEnabledFlagModificationEnabled = value;
                 OnPropertyChanged(nameof(IsEnabledFlagModificationEnabled));
-                UpdateBatchConfigTrackProperty(tc => tc.ShouldModifyEnabledFlag = value);
+                UpdateGlobalModificationFlag(tc => tc.ShouldModifyEnabledFlag = value);
             }
         }
     }
@@ -117,7 +118,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _isForcedTrack = value;
                 OnPropertyChanged(nameof(IsForcedTrack));
-                UpdateBatchConfigTrackProperty(tc => tc.Forced = value);
+                UpdateBatchConfigTrackProperty(tc => tc.Forced = value, ftv => ftv.Forced = value);
             }
         }
     }
@@ -133,7 +134,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _isForcedFlagModificationEnabled = value;
                 OnPropertyChanged(nameof(IsForcedFlagModificationEnabled));
-                UpdateBatchConfigTrackProperty(tc => tc.ShouldModifyForcedFlag = value);
+                UpdateGlobalModificationFlag(tc => tc.ShouldModifyForcedFlag = value);
             }
         }
     }
@@ -149,7 +150,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _trackName = value;
                 OnPropertyChanged(nameof(TrackName));
-                UpdateBatchConfigTrackProperty(tc => tc.Name = value);
+                UpdateBatchConfigTrackProperty(tc => tc.Name = value, ftv => ftv.Name = value);
             }
         }
     }
@@ -165,7 +166,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _isTrackNameModificationEnabled = value;
                 OnPropertyChanged(nameof(IsTrackNameModificationEnabled));
-                UpdateBatchConfigTrackProperty(tc => tc.ShouldModifyName = value);
+                UpdateGlobalModificationFlag(tc => tc.ShouldModifyName = value);
             }
         }
     }
@@ -181,7 +182,16 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _selectedLanguage = value;
                 OnPropertyChanged(nameof(SelectedLanguage));
-                UpdateBatchConfigTrackProperty(tc => tc.Language = value);
+
+                // Only warn when null comes from outside the internal sync path (e.g., ComboBox clearing its selection).
+                // During internal resets (ApplyTrackProperties), _suppressBatchConfigUpdate is true and null is expected.
+                if (value is null && !_suppressBatchConfigUpdate)
+                {
+                    LogSelectedLanguageNullFallback();
+                }
+
+                MatroskaLanguageOption language = value ?? MatroskaLanguageOption.Undetermined;
+                UpdateBatchConfigTrackProperty(tc => tc.Language = language, ftv => ftv.Language = language);
             }
         }
     }
@@ -197,7 +207,7 @@ public abstract partial class TrackViewModelBase : ObservableObject
             {
                 _isSelectedLanguageModificationEnabled = value;
                 OnPropertyChanged(nameof(IsSelectedLanguageModificationEnabled));
-                UpdateBatchConfigTrackProperty(tc => tc.ShouldModifyLanguage = value);
+                UpdateGlobalModificationFlag(tc => tc.ShouldModifyLanguage = value);
             }
         }
     }
@@ -209,12 +219,13 @@ public abstract partial class TrackViewModelBase : ObservableObject
 
     public bool ShowTrackAvailabilityText => _uiPreferences.ShowTrackAvailabilityText;
 
-    protected TrackViewModelBase(ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences)
+    protected TrackViewModelBase(ILogger logger, ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences)
     {
+        _logger = logger;
         _batchConfiguration = batchConfiguration;
         _uiPreferences = uiPreferences;
         _languages = languageProvider.Languages;
-        
+
         // Subscribe to property changes on the service
         _uiPreferences.PropertyChanged += OnUIPreferencesChanged;
     }
@@ -270,10 +281,10 @@ public abstract partial class TrackViewModelBase : ObservableObject
     {
         int available = GetTrackAvailabilityCount(trackIndex);
         int total = TotalFileCount;
-        
+
         if (total == 0)
             return "0/0";
-        
+
         return $"{available}/{total}";
     }
 
@@ -358,18 +369,20 @@ public abstract partial class TrackViewModelBase : ObservableObject
     /// Updates the properties of the currently selected track in the batch configuration using the provided update action.
     /// </summary>
     /// <remarks>
-    /// This method applies the provided update action to both:
+    /// This method applies the provided update actions to both:
     /// <list type="bullet">
     /// <item>The global track collection (used for UI display) - triggers PropertyChanged which fires StateChanged</item>
-    /// <item>All per-file track configurations (used for command generation) - updated silently</item>
+    /// <item>All per-file track value collections (used for command generation) - updated silently</item>
     /// </list>
     /// The global track update will trigger the StateChanged event through its PropertyChanged handler,
     /// ensuring the UI and command generation stay synchronized.
     /// If updates are suppressed or no track is selected, the method performs no operation.
     /// </remarks>
-    /// <param name="updateAction">An <see cref="Action{TrackConfiguration}"/> delegate that defines the update to apply to the selected track's
-    /// configuration.</param>
-    protected virtual void UpdateBatchConfigTrackProperty(Action<TrackConfiguration> updateAction)
+    /// <param name="globalUpdateAction">An <see cref="Action{TrackConfiguration}"/> delegate that defines the update to apply to the global track configuration.</param>
+    /// <param name="perFileUpdateAction">An <see cref="Action{FileTrackValues}"/> delegate that defines the update to apply to each per-file track value.</param>
+    protected virtual void UpdateBatchConfigTrackProperty(
+        Action<TrackConfiguration> globalUpdateAction,
+        Action<FileTrackValues> perFileUpdateAction)
     {
         // If suppressing updates, do nothing to avoid (potential) recursion.
         if (_suppressBatchConfigUpdate)
@@ -382,24 +395,50 @@ public abstract partial class TrackViewModelBase : ObservableObject
         if (index < 0 || index >= tracks.Count)
             return;
 
-        // First, update all per-file configurations silently (without triggering events)
+        // First, update all per-file value collections silently (without triggering events)
         // This ensures command generation uses the updated values
         var trackType = SelectedTrack.Type;
         foreach (var kvp in _batchConfiguration.FileConfigurations)
         {
             var fileConfig = kvp.Value;
             var fileTracks = fileConfig.GetTrackListForType(trackType);
-            
+
             // Only update if this file actually has this track
             if (index >= 0 && index < fileTracks.Count)
             {
-                updateAction(fileTracks[index]);
+                perFileUpdateAction(fileTracks[index]);
             }
         }
 
         // Finally, apply the update action to the global track configuration
         // This will trigger PropertyChanged -> TrackConfiguration_PropertyChanged -> StateChanged
         // which updates CanProcessBatch and regenerates commands
+        globalUpdateAction(tracks[index]);
+    }
+
+    /// <summary>
+    /// Updates only the global <see cref="TrackConfiguration"/> for a modification flag (e.g. <c>ShouldModify*</c>).
+    /// Per-file track values do not carry modification flags, so only the global track is updated.
+    /// </summary>
+    /// <remarks>
+    /// If updates are suppressed or no track is selected, the method performs no operation.
+    /// </remarks>
+    /// <param name="updateAction">An <see cref="Action{TrackConfiguration}"/> delegate that sets the modification flag on the global track configuration.</param>
+    protected virtual void UpdateGlobalModificationFlag(Action<TrackConfiguration> updateAction)
+    {
+        // If suppressing updates, do nothing to avoid (potential) recursion.
+        if (_suppressBatchConfigUpdate)
+            return;
+        if (SelectedTrack == null || GetTracks() == null)
+            return;
+
+        int index = SelectedTrack.Index;
+        var tracks = GetTracks();
+        if (index < 0 || index >= tracks.Count)
+            return;
+
+        // Apply the update action to the global track configuration only
+        // This will trigger PropertyChanged -> TrackConfiguration_PropertyChanged -> StateChanged
         updateAction(tracks[index]);
     }
 
@@ -422,38 +461,43 @@ public abstract partial class TrackViewModelBase : ObservableObject
     /// name="track"/> is <see langword="null"/>, all track-related properties are reset to default values.</param>
     private void ApplyTrackProperties(TrackConfiguration? track)
     {
-        // If suppressing updates, do nothing to avoid (potential) recursion.
+        // Suppress batch config updates while synchronizing properties to avoid (potential) recursion.
         _suppressBatchConfigUpdate = true;
 
-        // TODO: Need a better way to reset properties when no track is provided.
-        if (track is null)
+        try
         {
-            IsDefaultTrack = false;
-            IsEnabledTrack = true;
-            IsForcedTrack = false;
-            TrackName = string.Empty;
-            SelectedLanguage = null;
-            IsDefaultFlagModificationEnabled = false;
-            IsEnabledFlagModificationEnabled = false;
-            IsForcedFlagModificationEnabled = false;
-            IsTrackNameModificationEnabled = false;
-            IsSelectedLanguageModificationEnabled = false;
+            // TODO: Need a better way to reset properties when no track is provided.
+            if (track is null)
+            {
+                IsDefaultTrack = false;
+                IsEnabledTrack = true;
+                IsForcedTrack = false;
+                TrackName = string.Empty;
+                SelectedLanguage = null;
+                IsDefaultFlagModificationEnabled = false;
+                IsEnabledFlagModificationEnabled = false;
+                IsForcedFlagModificationEnabled = false;
+                IsTrackNameModificationEnabled = false;
+                IsSelectedLanguageModificationEnabled = false;
 
-            return;
+                return;
+            }
+
+            // Synchronize properties with the selected track.
+            IsDefaultTrack = track.Default;
+            IsEnabledTrack = track.Enabled;
+            IsForcedTrack = track.Forced;
+            TrackName = track.Name;
+            SelectedLanguage = track.Language;
+            IsDefaultFlagModificationEnabled = track.ShouldModifyDefaultFlag;
+            IsEnabledFlagModificationEnabled = track.ShouldModifyEnabledFlag;
+            IsForcedFlagModificationEnabled = track.ShouldModifyForcedFlag;
+            IsTrackNameModificationEnabled = track.ShouldModifyName;
+            IsSelectedLanguageModificationEnabled = track.ShouldModifyLanguage;
         }
-
-        // Synchronize properties with the selected track.
-        IsDefaultTrack = track.Default;
-        IsEnabledTrack = track.Enabled;
-        IsForcedTrack = track.Forced;
-        TrackName = track.Name;
-        SelectedLanguage = track.Language;
-        IsDefaultFlagModificationEnabled = track.ShouldModifyDefaultFlag;
-        IsEnabledFlagModificationEnabled = track.ShouldModifyEnabledFlag;
-        IsForcedFlagModificationEnabled = track.ShouldModifyForcedFlag;
-        IsTrackNameModificationEnabled = track.ShouldModifyName;
-        IsSelectedLanguageModificationEnabled = track.ShouldModifyLanguage;
-
-        _suppressBatchConfigUpdate = false;
+        finally
+        {
+            _suppressBatchConfigUpdate = false;
+        }
     }
 }

--- a/src/MatroskaBatchFlow.Uno/Presentation/VideoViewModel.cs
+++ b/src/MatroskaBatchFlow.Uno/Presentation/VideoViewModel.cs
@@ -28,8 +28,8 @@ public partial class VideoViewModel : TrackViewModelBase
     /// </summary>
     public bool IsFileListPopulated => _batchConfiguration.FileList.Count > 0;
 
-    public VideoViewModel(ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences)
-        : base(languageProvider, batchConfiguration, uiPreferences)
+    public VideoViewModel(ILogger<VideoViewModel> logger, ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences)
+        : base(logger, languageProvider, batchConfiguration, uiPreferences)
     {
         VideoTracks = [.. _batchConfiguration.VideoTracks];
 

--- a/tests/MatroskaBatchFlow.Core.UnitTests/Services/BatchConfigurationTests.cs
+++ b/tests/MatroskaBatchFlow.Core.UnitTests/Services/BatchConfigurationTests.cs
@@ -263,15 +263,39 @@ public class BatchConfigurationTests
         var newFileId = Guid.NewGuid();
         
         // Create file configuration with all track types
-        var audioTrack = new TrackConfiguration(new MediaInfoResultBuilder()
-            .AddTrackOfType(TrackType.Audio)
-            .Build().Media.Track.First(t => t.Type == TrackType.Audio));
-        var videoTrack = new TrackConfiguration(new MediaInfoResultBuilder()
-            .AddTrackOfType(TrackType.Video)
-            .Build().Media.Track.First(t => t.Type == TrackType.Video));
-        var subtitleTrack = new TrackConfiguration(new MediaInfoResultBuilder()
-            .AddTrackOfType(TrackType.Text)
-            .Build().Media.Track.First(t => t.Type == TrackType.Text));
+        var audioTrack = new FileTrackValues
+        {
+            ScannedTrackInfo = new MediaInfoResultBuilder()
+                .AddTrackOfType(TrackType.Audio)
+                .Build().Media.Track.First(t => t.Type == TrackType.Audio),
+            Type = TrackType.Audio,
+            Index = 0,
+            Default = false,
+            Forced = false,
+            Enabled = false
+        };
+        var videoTrack = new FileTrackValues
+        {
+            ScannedTrackInfo = new MediaInfoResultBuilder()
+                .AddTrackOfType(TrackType.Video)
+                .Build().Media.Track.First(t => t.Type == TrackType.Video),
+            Type = TrackType.Video,
+            Index = 0,
+            Default = false,
+            Forced = false,
+            Enabled = false
+        };
+        var subtitleTrack = new FileTrackValues
+        {
+            ScannedTrackInfo = new MediaInfoResultBuilder()
+                .AddTrackOfType(TrackType.Text)
+                .Build().Media.Track.First(t => t.Type == TrackType.Text),
+            Type = TrackType.Text,
+            Index = 0,
+            Default = false,
+            Forced = false,
+            Enabled = false
+        };
         
         var fileConfig = new FileTrackConfiguration
         {
@@ -303,15 +327,18 @@ public class BatchConfigurationTests
         var oldFileId = Guid.NewGuid();
         var newFileId = Guid.NewGuid();
         
-        // Create audio track with user modifications
-        var audioTrack = new TrackConfiguration(new MediaInfoResultBuilder()
-            .AddTrackOfType(TrackType.Audio)
-            .Build().Media.Track.First(t => t.Type == TrackType.Audio))
+        // Create audio track with user-modified values
+        var audioTrack = new FileTrackValues
         {
+            ScannedTrackInfo = new MediaInfoResultBuilder()
+                .AddTrackOfType(TrackType.Audio)
+                .Build().Media.Track.First(t => t.Type == TrackType.Audio),
+            Type = TrackType.Audio,
+            Index = 0,
             Name = "Modified Track Name",
             Default = true,
-            ShouldModifyName = true,
-            ShouldModifyDefaultFlag = true
+            Forced = false,
+            Enabled = false
         };
         
         var fileConfig = new FileTrackConfiguration
@@ -324,13 +351,11 @@ public class BatchConfigurationTests
         // Act
         config.MigrateFileConfiguration(oldFileId, newFileId);
 
-        // Assert - user modifications should be preserved
+        // Assert - user-modified values should be preserved after migration
         var migratedConfig = config.FileConfigurations[newFileId];
         var migratedTrack = migratedConfig.AudioTracks[0];
         
         Assert.Equal("Modified Track Name", migratedTrack.Name);
         Assert.True(migratedTrack.Default);
-        Assert.True(migratedTrack.ShouldModifyName);
-        Assert.True(migratedTrack.ShouldModifyDefaultFlag);
     }
 }

--- a/tests/MatroskaBatchFlow.Core.UnitTests/Services/BatchTrackConfigurationInitializerTests.cs
+++ b/tests/MatroskaBatchFlow.Core.UnitTests/Services/BatchTrackConfigurationInitializerTests.cs
@@ -19,6 +19,7 @@ public class BatchTrackConfigurationInitializerTests
     {
         var mockLanguageProvider = Substitute.For<ILanguageProvider>();
         mockLanguageProvider.Languages.Returns(ImmutableList<MatroskaLanguageOption>.Empty);
+        mockLanguageProvider.Resolve(Arg.Any<string?>()).Returns(MatroskaLanguageOption.Undetermined);
         return mockLanguageProvider;
     }
 

--- a/tests/MatroskaBatchFlow.Core.UnitTests/Services/BatchTrackConfigurationInitializerTests.cs
+++ b/tests/MatroskaBatchFlow.Core.UnitTests/Services/BatchTrackConfigurationInitializerTests.cs
@@ -54,7 +54,7 @@ public class BatchTrackConfigurationInitializerTests
     {
         languageProvider ??= CreateMockLanguageProvider();
         var trackConfigFactory = new TrackConfigurationFactory(languageProvider);
-        return new BatchTrackConfigurationInitializer(batchConfig, trackConfigFactory);
+        return new BatchTrackConfigurationInitializer(batchConfig, trackConfigFactory, languageProvider);
     }
 
     [Fact]
@@ -232,5 +232,86 @@ public class BatchTrackConfigurationInitializerTests
         // FileConfiguration should be created even with no tracks
         Assert.True(fileConfigs.ContainsKey(scannedFile.Id));
         Assert.Empty(fileConfigs[scannedFile.Id].AudioTracks);
+    }
+
+    [Fact]
+    public void Initialize_PerFileTracksAreFileTrackValuesWithScannedData()
+    {
+        // Arrange
+        var (mockConfig, fileConfigs, _, _, _) = CreateMockConfig();
+        var initializer = CreateInitializer(mockConfig);
+
+        var mediaInfoResult = new MediaInfoResultBuilder()
+            .WithCreatingLibrary()
+            .AddTrackOfType(TrackType.Audio)
+            .AddTrackOfType(TrackType.Audio)
+            .Build();
+        var scannedFile = new ScannedFileInfo(mediaInfoResult, "file.mkv");
+        mockConfig.FileList.Add(scannedFile);
+
+        // Act
+        initializer.Initialize(scannedFile, TrackType.Audio);
+
+        // Assert - per-file tracks are FileTrackValues initialized from the scan
+        var fileConfig = fileConfigs[scannedFile.Id];
+        Assert.Equal(2, fileConfig.AudioTracks.Count);
+
+        Assert.Equal(TrackType.Audio, fileConfig.AudioTracks[0].Type);
+        Assert.Equal(0, fileConfig.AudioTracks[0].Index);
+        Assert.NotNull(fileConfig.AudioTracks[0].ScannedTrackInfo);
+
+        Assert.Equal(TrackType.Audio, fileConfig.AudioTracks[1].Type);
+        Assert.Equal(1, fileConfig.AudioTracks[1].Index);
+        Assert.NotNull(fileConfig.AudioTracks[1].ScannedTrackInfo);
+    }
+
+    [Fact]
+    public void Initialize_FilesAddedAfterUserConfigure_ReceiveFileTrackValues()
+    {
+        // Regression test for issue #85: files added after processing were skipped because
+        // per-file TrackConfiguration objects always had ShouldModify* = false.
+        // Now per-file tracks are FileTrackValues with no ShouldModify* fields,
+        // so the argument generator reads ShouldModify* from global tracks for every file.
+        // Arrange
+        var (mockConfig, fileConfigs, audioTracks, _, _) = CreateMockConfig();
+        var initializer = CreateInitializer(mockConfig);
+
+        var firstFile = new ScannedFileInfo(
+            new MediaInfoResultBuilder()
+                .WithCreatingLibrary()
+                .AddTrackOfType(TrackType.Audio)
+                .Build(),
+            "file1.mkv"
+        );
+        mockConfig.FileList.Add(firstFile);
+        initializer.Initialize(firstFile, TrackType.Audio);
+
+        // Simulate user enabling modifications on the global track
+        audioTracks[0].ShouldModifyLanguage = true;
+        audioTracks[0].ShouldModifyName = true;
+
+        // Add a second file after modifications were configured (this was the bug scenario)
+        var secondFile = new ScannedFileInfo(
+            new MediaInfoResultBuilder()
+                .WithCreatingLibrary()
+                .AddTrackOfType(TrackType.Audio)
+                .Build(),
+            "file2.mkv"
+        );
+        mockConfig.FileList.Add(secondFile);
+
+        // Act
+        initializer.Initialize(secondFile, TrackType.Audio);
+
+        // Assert - second file receives FileTrackValues (not TrackConfiguration with ShouldModify* = false)
+        Assert.True(fileConfigs.ContainsKey(secondFile.Id));
+        var secondFileConfig = fileConfigs[secondFile.Id];
+        Assert.Single(secondFileConfig.AudioTracks);
+        Assert.Equal(TrackType.Audio, secondFileConfig.AudioTracks[0].Type);
+        Assert.Equal(0, secondFileConfig.AudioTracks[0].Index);
+
+        // Global tracks still hold the ShouldModify* flags set by the user
+        Assert.True(audioTracks[0].ShouldModifyLanguage);
+        Assert.True(audioTracks[0].ShouldModifyName);
     }
 }

--- a/tests/MatroskaBatchFlow.Core.UnitTests/Services/LanguageProviderTests.cs
+++ b/tests/MatroskaBatchFlow.Core.UnitTests/Services/LanguageProviderTests.cs
@@ -194,6 +194,150 @@ public class LanguageProviderTests : IDisposable
         Assert.IsAssignableFrom<System.Collections.Immutable.ImmutableList<MatroskaLanguageOption>>(provider.Languages);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_ReturnsUndetermined_WhenLanguageCodeIsNullOrWhitespace(string? languageCode)
+    {
+        // Arrange
+        var provider = CreateProviderWithTestLanguages();
+
+        // Act
+        var result = provider.Resolve(languageCode);
+
+        // Assert
+        Assert.Equal(MatroskaLanguageOption.Undetermined, result);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsUndetermined_WhenNoMatchFound()
+    {
+        // Arrange
+        var provider = CreateProviderWithTestLanguages();
+
+        // Act
+        var result = provider.Resolve("nonexistent");
+
+        // Assert
+        Assert.Equal(MatroskaLanguageOption.Undetermined, result);
+    }
+
+    [Fact]
+    public void Resolve_MatchesByIso639_2_b()
+    {
+        // Arrange — French has iso639_2_b "fre" (distinct from iso639_2_t "fra")
+        var provider = CreateProviderWithTestLanguages();
+
+        // Act
+        var result = provider.Resolve("fre");
+
+        // Assert
+        Assert.Equal("French", result.Name);
+    }
+
+    [Fact]
+    public void Resolve_MatchesByIso639_2_t()
+    {
+        // Arrange — French has iso639_2_t "fra" (distinct from iso639_2_b "fre")
+        var provider = CreateProviderWithTestLanguages();
+
+        // Act
+        var result = provider.Resolve("fra");
+
+        // Assert
+        Assert.Equal("French", result.Name);
+    }
+
+    [Fact]
+    public void Resolve_MatchesByIso639_1()
+    {
+        // Arrange
+        var provider = CreateProviderWithTestLanguages();
+
+        // Act
+        var result = provider.Resolve("en");
+
+        // Assert
+        Assert.Equal("English", result.Name);
+    }
+
+    [Fact]
+    public void Resolve_MatchesByIso639_3()
+    {
+        // Arrange — "cmn" only appears in the ISO 639-3 field, so this isolates that match path.
+        var provider = CreateProviderWithLanguageWithoutIso639_1();
+
+        // Act
+        var result = provider.Resolve("cmn");
+
+        // Assert
+        Assert.Equal("Chinese", result.Name);
+    }
+
+    [Fact]
+    public void Resolve_MatchesByName()
+    {
+        // Arrange
+        var provider = CreateProviderWithTestLanguages();
+
+        // Act
+        var result = provider.Resolve("French");
+
+        // Assert
+        Assert.Equal("French", result.Name);
+    }
+
+    [Fact]
+    public void Resolve_MatchesByCode()
+    {
+        // Arrange — Code is derived: iso639_1 ?? iso639_2_b, so "fr" for French.
+        // "fr" also matches iso639_1 directly. Use a language with null iso639_1
+        // to isolate the Code path.
+        var provider = CreateProviderWithLanguageWithoutIso639_1();
+
+        // Act — Code falls back to iso639_2_b "zho" when iso639_1 is null
+        var result = provider.Resolve("zho");
+
+        // Assert
+        Assert.Equal("Chinese", result.Name);
+    }
+
+    [Fact]
+    public void Resolve_IsCaseInsensitive()
+    {
+        // Arrange
+        var provider = CreateProviderWithTestLanguages();
+
+        // Act
+        var result = provider.Resolve("ENG");
+
+        // Assert
+        Assert.Equal("English", result.Name);
+    }
+
+    private LanguageProvider CreateProviderWithTestLanguages()
+    {
+        var testFile = CreateTestLanguageFile("resolve_test.json");
+        var options = CreateOptions(testFile);
+        return new LanguageProvider(options, _logger);
+    }
+
+    private LanguageProvider CreateProviderWithLanguageWithoutIso639_1()
+    {
+        var testFile = Path.Combine(_testFilesDirectory, "resolve_no_iso1.json");
+        var json = """
+            {
+                "languages": [
+                    { "name": "Chinese", "iso639_1": null, "iso639_2_b": "zho", "iso639_2_t": "chi", "iso639_3": "cmn" }
+                ]
+            }
+            """;
+        File.WriteAllText(testFile, json);
+        var options = CreateOptions(testFile);
+        return new LanguageProvider(options, _logger);
+    }
+
     private static IOptions<LanguageOptions> CreateOptions(string filePath)
     {
         var options = Options.Create(new LanguageOptions { FilePath = filePath });

--- a/tests/MatroskaBatchFlow.Core.UnitTests/Services/TrackConfigurationFactoryTests.cs
+++ b/tests/MatroskaBatchFlow.Core.UnitTests/Services/TrackConfigurationFactoryTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using MatroskaBatchFlow.Core.Enums;
 using MatroskaBatchFlow.Core.Models;
 using MatroskaBatchFlow.Core.Services;
@@ -13,18 +12,19 @@ namespace MatroskaBatchFlow.Core.UnitTests.Services;
 /// </summary>
 public class TrackConfigurationFactoryTests
 {
-    private static ILanguageProvider CreateMockLanguageProvider(IEnumerable<MatroskaLanguageOption>? languages = null)
+    private readonly ILanguageProvider _mockLanguageProvider = Substitute.For<ILanguageProvider>();
+
+    public TrackConfigurationFactoryTests()
     {
-        var mockLanguageProvider = Substitute.For<ILanguageProvider>();
-        mockLanguageProvider.Languages.Returns(languages?.ToImmutableList() ?? ImmutableList<MatroskaLanguageOption>.Empty);
-        return mockLanguageProvider;
+        // Default: any unmatched code resolves to Undetermined.
+        _mockLanguageProvider.Resolve(Arg.Any<string?>()).Returns(MatroskaLanguageOption.Undetermined);
     }
 
     [Fact]
     public void Create_SetsBasicProperties()
     {
         // Arrange
-        var factory = new TrackConfigurationFactory(CreateMockLanguageProvider());
+        var factory = new TrackConfigurationFactory(_mockLanguageProvider);
         var trackInfo = new TrackInfoBuilder()
             .WithType(TrackType.Audio)
             .WithTitle("English Commentary")
@@ -49,7 +49,7 @@ public class TrackConfigurationFactoryTests
     public void Create_SetsEmptyNameWhenTitleIsNull()
     {
         // Arrange
-        var factory = new TrackConfigurationFactory(CreateMockLanguageProvider());
+        var factory = new TrackConfigurationFactory(_mockLanguageProvider);
         var trackInfo = new TrackInfoBuilder()
             .WithType(TrackType.Video)
             .WithStreamKindID(0)
@@ -63,7 +63,7 @@ public class TrackConfigurationFactoryTests
     }
 
     [Fact]
-    public void Create_ResolvesLanguageFromIso639_2_b()
+    public void Create_DelegatesToResolveAndUsesResult()
     {
         // Arrange
         var englishLanguage = new MatroskaLanguageOption(
@@ -72,7 +72,8 @@ public class TrackConfigurationFactoryTests
             iso639_2_b: "eng",
             iso639_2_t: "eng",
             iso639_3: "eng");
-        var factory = new TrackConfigurationFactory(CreateMockLanguageProvider([englishLanguage]));
+        _mockLanguageProvider.Resolve("eng").Returns(englishLanguage);
+        var factory = new TrackConfigurationFactory(_mockLanguageProvider);
         var trackInfo = new TrackInfoBuilder()
             .WithType(TrackType.Audio)
             .WithLanguage("eng")
@@ -87,7 +88,7 @@ public class TrackConfigurationFactoryTests
     }
 
     [Fact]
-    public void Create_ResolvesLanguageFromIso639_1()
+    public void Create_PassesLanguageCodeToResolve()
     {
         // Arrange
         var japaneseLanguage = new MatroskaLanguageOption(
@@ -96,7 +97,8 @@ public class TrackConfigurationFactoryTests
             iso639_2_b: "jpn",
             iso639_2_t: "jpn",
             iso639_3: "jpn");
-        var factory = new TrackConfigurationFactory(CreateMockLanguageProvider([japaneseLanguage]));
+        _mockLanguageProvider.Resolve("ja").Returns(japaneseLanguage);
+        var factory = new TrackConfigurationFactory(_mockLanguageProvider);
         var trackInfo = new TrackInfoBuilder()
             .WithType(TrackType.Audio)
             .WithLanguage("ja")
@@ -114,7 +116,7 @@ public class TrackConfigurationFactoryTests
     public void Create_ReturnsUndeterminedForUnknownLanguage()
     {
         // Arrange
-        var factory = new TrackConfigurationFactory(CreateMockLanguageProvider());
+        var factory = new TrackConfigurationFactory(_mockLanguageProvider);
         var trackInfo = new TrackInfoBuilder()
             .WithType(TrackType.Audio)
             .WithLanguage("xyz")
@@ -132,7 +134,7 @@ public class TrackConfigurationFactoryTests
     public void Create_ReturnsUndeterminedForEmptyLanguage()
     {
         // Arrange
-        var factory = new TrackConfigurationFactory(CreateMockLanguageProvider());
+        var factory = new TrackConfigurationFactory(_mockLanguageProvider);
         var trackInfo = new TrackInfoBuilder()
             .WithType(TrackType.Audio)
             .WithLanguage(string.Empty)
@@ -150,7 +152,7 @@ public class TrackConfigurationFactoryTests
     public void Create_ReturnsUndeterminedForWhitespaceLanguage()
     {
         // Arrange
-        var factory = new TrackConfigurationFactory(CreateMockLanguageProvider());
+        var factory = new TrackConfigurationFactory(_mockLanguageProvider);
         var trackInfo = new TrackInfoBuilder()
             .WithType(TrackType.Audio)
             .WithLanguage("   ")
@@ -168,7 +170,7 @@ public class TrackConfigurationFactoryTests
     public void Create_ThrowsForNullTrackInfo()
     {
         // Arrange
-        var factory = new TrackConfigurationFactory(CreateMockLanguageProvider());
+        var factory = new TrackConfigurationFactory(_mockLanguageProvider);
 
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => factory.Create(null!, TrackType.Audio, 0));

--- a/tests/MatroskaBatchFlow.Uno.IntegrationTests/TrackModificationIntegrationTests.cs
+++ b/tests/MatroskaBatchFlow.Uno.IntegrationTests/TrackModificationIntegrationTests.cs
@@ -33,6 +33,7 @@ public class TrackModificationIntegrationTests
         // Mock only external dependencies (language data, UI preferences)
         var mockLanguageProvider = Substitute.For<ILanguageProvider>();
         mockLanguageProvider.Languages.Returns(ImmutableList<MatroskaLanguageOption>.Empty);
+        mockLanguageProvider.Resolve(Arg.Any<string?>()).Returns(MatroskaLanguageOption.Undetermined);
         var mockUIPreferences = Substitute.For<IUIPreferencesService>();
 
         var file1Path = "file1.mkv";

--- a/tests/MatroskaBatchFlow.Uno.IntegrationTests/TrackModificationIntegrationTests.cs
+++ b/tests/MatroskaBatchFlow.Uno.IntegrationTests/TrackModificationIntegrationTests.cs
@@ -61,7 +61,7 @@ public class TrackModificationIntegrationTests
 
         // Initialize per-file configurations
         var trackConfigFactory = new TrackConfigurationFactory(mockLanguageProvider);
-        var initializer = new BatchTrackConfigurationInitializer(batchConfig, trackConfigFactory);
+        var initializer = new BatchTrackConfigurationInitializer(batchConfig, trackConfigFactory, mockLanguageProvider);
         initializer.Initialize(file1, TrackType.Text);
         initializer.Initialize(file2, TrackType.Text);
 
@@ -70,7 +70,7 @@ public class TrackModificationIntegrationTests
         batchConfig.StateChanged += (_, __) => tcs.TrySetResult(true);
 
         // Create SubtitleViewModel using real BatchConfiguration
-        var subtitleViewModel = new SubtitleViewModel(mockLanguageProvider, batchConfig, mockUIPreferences);
+        var subtitleViewModel = new SubtitleViewModel(Substitute.For<ILogger<SubtitleViewModel>>(), mockLanguageProvider, batchConfig, mockUIPreferences);
 
         // Select track 17 (index 16) - only exists in file2
         Assert.Equal(17, batchConfig.SubtitleTracks.Count);
@@ -104,10 +104,9 @@ public class TrackModificationIntegrationTests
         var file2Config = batchConfig.FileConfigurations[file2.Id];
         Assert.Equal(17, file2Config.SubtitleTracks.Count);
         Assert.Equal("Track17Modified", file2Config.SubtitleTracks[16].Name);
-        Assert.True(file2Config.SubtitleTracks[16].ShouldModifyName);
 
         // Verify command generation works correctly
-        var argumentsGenerator = new MkvPropeditArgumentsGenerator();
+        var argumentsGenerator = new MkvPropeditArgumentsGenerator(Substitute.For<ILogger<MkvPropeditArgumentsGenerator>>());
         var commands = argumentsGenerator.BuildBatchArguments(batchConfig);
 
         Assert.Single(commands);

--- a/tests/MatroskaBatchFlow.Uno.UnitTests/Presentation/AudioViewModelTests.cs
+++ b/tests/MatroskaBatchFlow.Uno.UnitTests/Presentation/AudioViewModelTests.cs
@@ -7,6 +7,7 @@ using MatroskaBatchFlow.Core.UnitTests.Builders;
 using MatroskaBatchFlow.Core.Utilities;
 using MatroskaBatchFlow.Uno.Contracts.Services;
 using MatroskaBatchFlow.Uno.Presentation;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace MatroskaBatchFlow.Uno.UnitTests.Presentation;
@@ -16,12 +17,14 @@ public class AudioViewModelTests
     private readonly ILanguageProvider _languageProvider;
     private readonly IBatchConfiguration _batchConfiguration;
     private readonly IUIPreferencesService _uiPreferences;
+    private readonly ILogger<AudioViewModel> _logger;
 
     public AudioViewModelTests()
     {
         _languageProvider = Substitute.For<ILanguageProvider>();
         _batchConfiguration = Substitute.For<IBatchConfiguration>();
         _uiPreferences = Substitute.For<IUIPreferencesService>();
+        _logger = Substitute.For<ILogger<AudioViewModel>>();
 
         _languageProvider.Languages.Returns([]);
         _batchConfiguration.AudioTracks.Returns(new ObservableCollection<TrackConfiguration>());
@@ -46,7 +49,7 @@ public class AudioViewModelTests
         _batchConfiguration.AudioTracks.Returns(audioTracks);
 
         // Act
-        var viewModel = new AudioViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new AudioViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.Single(viewModel.AudioTracks);
@@ -70,7 +73,7 @@ public class AudioViewModelTests
         _batchConfiguration.AudioTracks.Returns(audioTracks);
 
         // Act
-        var viewModel = new AudioViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new AudioViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.NotNull(viewModel.SelectedTrack);
@@ -91,7 +94,7 @@ public class AudioViewModelTests
         _batchConfiguration.FileList.Returns(fileList);
 
         // Act
-        var viewModel = new AudioViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new AudioViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.True(viewModel.IsFileListPopulated);
@@ -103,7 +106,7 @@ public class AudioViewModelTests
         // Arrange - fileList is empty by default
 
         // Act
-        var viewModel = new AudioViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new AudioViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.False(viewModel.IsFileListPopulated);
@@ -116,7 +119,7 @@ public class AudioViewModelTests
         var fileList = new UniqueObservableCollection<ScannedFileInfo>(Substitute.For<IScannedFileInfoPathComparer>());
         _batchConfiguration.FileList.Returns(fileList);
 
-        var viewModel = new AudioViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new AudioViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
         Assert.False(viewModel.IsFileListPopulated);
 
         var mediaInfoResult = new MediaInfoResultBuilder()
@@ -145,7 +148,7 @@ public class AudioViewModelTests
         var audioTracks = new ObservableCollection<TrackConfiguration>();
         _batchConfiguration.AudioTracks.Returns(audioTracks);
 
-        var viewModel = new AudioViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new AudioViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
         Assert.Empty(viewModel.AudioTracks);
 
         var mediaInfoResult = new MediaInfoResultBuilder()
@@ -169,7 +172,7 @@ public class AudioViewModelTests
         var initialTracks = new ObservableCollection<TrackConfiguration>();
         _batchConfiguration.AudioTracks.Returns(initialTracks);
 
-        var viewModel = new AudioViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new AudioViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         var mediaInfoResult = new MediaInfoResultBuilder()
             .WithCreatingLibrary()
@@ -199,7 +202,7 @@ public class AudioViewModelTests
         var audioTracks = new ObservableCollection<TrackConfiguration>();
         _batchConfiguration.AudioTracks.Returns(audioTracks);
 
-        var viewModel = new AudioViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new AudioViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
         int audioTracksChangedCount = 0;
         viewModel.PropertyChanged += (s, e) =>
         {

--- a/tests/MatroskaBatchFlow.Uno.UnitTests/Presentation/SubtitleViewModelTests.cs
+++ b/tests/MatroskaBatchFlow.Uno.UnitTests/Presentation/SubtitleViewModelTests.cs
@@ -7,6 +7,7 @@ using MatroskaBatchFlow.Core.UnitTests.Builders;
 using MatroskaBatchFlow.Core.Utilities;
 using MatroskaBatchFlow.Uno.Contracts.Services;
 using MatroskaBatchFlow.Uno.Presentation;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace MatroskaBatchFlow.Uno.UnitTests.Presentation;
@@ -16,12 +17,14 @@ public class SubtitleViewModelTests
     private readonly ILanguageProvider _languageProvider;
     private readonly IBatchConfiguration _batchConfiguration;
     private readonly IUIPreferencesService _uiPreferences;
+    private readonly ILogger<SubtitleViewModel> _logger;
 
     public SubtitleViewModelTests()
     {
         _languageProvider = Substitute.For<ILanguageProvider>();
         _batchConfiguration = Substitute.For<IBatchConfiguration>();
         _uiPreferences = Substitute.For<IUIPreferencesService>();
+        _logger = Substitute.For<ILogger<SubtitleViewModel>>();
 
         _languageProvider.Languages.Returns([]);
         _batchConfiguration.SubtitleTracks.Returns(new ObservableCollection<TrackConfiguration>());
@@ -46,7 +49,7 @@ public class SubtitleViewModelTests
         _batchConfiguration.SubtitleTracks.Returns(subtitleTracks);
 
         // Act
-        var viewModel = new SubtitleViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new SubtitleViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.Single(viewModel.SubtitleTracks);
@@ -70,7 +73,7 @@ public class SubtitleViewModelTests
         _batchConfiguration.SubtitleTracks.Returns(subtitleTracks);
 
         // Act
-        var viewModel = new SubtitleViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new SubtitleViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.NotNull(viewModel.SelectedTrack);
@@ -91,7 +94,7 @@ public class SubtitleViewModelTests
         _batchConfiguration.FileList.Returns(fileList);
 
         // Act
-        var viewModel = new SubtitleViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new SubtitleViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.True(viewModel.IsFileListPopulated);
@@ -103,7 +106,7 @@ public class SubtitleViewModelTests
         // Arrange - fileList is empty by default
 
         // Act
-        var viewModel = new SubtitleViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new SubtitleViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.False(viewModel.IsFileListPopulated);
@@ -116,7 +119,7 @@ public class SubtitleViewModelTests
         var fileList = new UniqueObservableCollection<ScannedFileInfo>(Substitute.For<IScannedFileInfoPathComparer>());
         _batchConfiguration.FileList.Returns(fileList);
 
-        var viewModel = new SubtitleViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new SubtitleViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
         Assert.False(viewModel.IsFileListPopulated);
 
         var mediaInfoResult = new MediaInfoResultBuilder()
@@ -145,7 +148,7 @@ public class SubtitleViewModelTests
         var subtitleTracks = new ObservableCollection<TrackConfiguration>();
         _batchConfiguration.SubtitleTracks.Returns(subtitleTracks);
 
-        var viewModel = new SubtitleViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new SubtitleViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
         Assert.Empty(viewModel.SubtitleTracks);
 
         var mediaInfoResult = new MediaInfoResultBuilder()
@@ -169,7 +172,7 @@ public class SubtitleViewModelTests
         var initialTracks = new ObservableCollection<TrackConfiguration>();
         _batchConfiguration.SubtitleTracks.Returns(initialTracks);
 
-        var viewModel = new SubtitleViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new SubtitleViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         var mediaInfoResult = new MediaInfoResultBuilder()
             .WithCreatingLibrary()
@@ -199,7 +202,7 @@ public class SubtitleViewModelTests
         var subtitleTracks = new ObservableCollection<TrackConfiguration>();
         _batchConfiguration.SubtitleTracks.Returns(subtitleTracks);
 
-        var viewModel = new SubtitleViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new SubtitleViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
         int subtitleTracksChangedCount = 0;
         viewModel.PropertyChanged += (s, e) =>
         {

--- a/tests/MatroskaBatchFlow.Uno.UnitTests/Presentation/TrackViewModelBaseTests.cs
+++ b/tests/MatroskaBatchFlow.Uno.UnitTests/Presentation/TrackViewModelBaseTests.cs
@@ -6,6 +6,7 @@ using MatroskaBatchFlow.Core.UnitTests.Builders;
 using MatroskaBatchFlow.Core.Utilities;
 using MatroskaBatchFlow.Uno.Contracts.Services;
 using MatroskaBatchFlow.Uno.Presentation;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace MatroskaBatchFlow.Uno.UnitTests.Presentation;
@@ -19,6 +20,8 @@ namespace MatroskaBatchFlow.Uno.UnitTests.Presentation;
 /// facilitate testing scenarios.</remarks>
 public class TrackViewModelBaseTests
 {
+    private readonly ILogger _mockLogger = Substitute.For<ILogger>();
+
     /// <summary>
     /// Test implementation of TrackViewModelBase for testing purposes
     /// </summary>
@@ -26,8 +29,8 @@ public class TrackViewModelBaseTests
     {
         private readonly IList<TrackConfiguration> _testTracks;
 
-        public TestTrackViewModel(ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences, IList<TrackConfiguration> tracks)
-            : base(languageProvider, batchConfiguration, uiPreferences)
+        public TestTrackViewModel(ILogger logger, ILanguageProvider languageProvider, IBatchConfiguration batchConfiguration, IUIPreferencesService uiPreferences, IList<TrackConfiguration> tracks)
+            : base(logger, languageProvider, batchConfiguration, uiPreferences)
         {
             _testTracks = tracks;
             SetupEventHandlers();
@@ -74,10 +77,10 @@ public class TrackViewModelBaseTests
         var file2 = new ScannedFileInfo(mediaInfoResult, "file2.mkv");
 
         var file1Config = new FileTrackConfiguration { FilePath = file1.Path };
-        file1Config.SubtitleTracks.Add(new TrackConfiguration(trackInfo) { Type = TrackType.Text, Index = 0, Name = "Original" });
+        file1Config.SubtitleTracks.Add(new FileTrackValues { ScannedTrackInfo = trackInfo, Type = TrackType.Text, Index = 0, Name = "Original", Default = false, Forced = false, Enabled = false });
 
         var file2Config = new FileTrackConfiguration { FilePath = file2.Path };
-        file2Config.SubtitleTracks.Add(new TrackConfiguration(trackInfo) { Type = TrackType.Text, Index = 0, Name = "Original" });
+        file2Config.SubtitleTracks.Add(new FileTrackValues { ScannedTrackInfo = trackInfo, Type = TrackType.Text, Index = 0, Name = "Original", Default = false, Forced = false, Enabled = false });
 
         var fileConfigurations = new Dictionary<Guid, FileTrackConfiguration>
         {
@@ -88,7 +91,7 @@ public class TrackViewModelBaseTests
         mockBatchConfig.FileConfigurations.Returns(fileConfigurations);
 
         // Create view model
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
 
         // Set the selected track
         viewModel.SelectedTrack = globalTracks[0];
@@ -103,10 +106,8 @@ public class TrackViewModelBaseTests
 
         // Assert - verify per-file configurations were also updated
         Assert.Equal("Updated Name", file1Config.SubtitleTracks[0].Name);
-        Assert.True(file1Config.SubtitleTracks[0].ShouldModifyName);
 
         Assert.Equal("Updated Name", file2Config.SubtitleTracks[0].Name);
-        Assert.True(file2Config.SubtitleTracks[0].ShouldModifyName);
     }
 
     [Fact]
@@ -132,7 +133,7 @@ public class TrackViewModelBaseTests
         // File1 has track 0
         var file1 = new ScannedFileInfo(mediaInfoResult, "file1.mkv");
         var file1Config = new FileTrackConfiguration { FilePath = file1.Path };
-        file1Config.SubtitleTracks.Add(new TrackConfiguration(trackInfo) { Type = TrackType.Text, Index = 0, Name = "Original" });
+        file1Config.SubtitleTracks.Add(new FileTrackValues { ScannedTrackInfo = trackInfo, Type = TrackType.Text, Index = 0, Name = "Original", Default = false, Forced = false, Enabled = false });
 
         // File2 has NO tracks (different track count)
         var file2 = new ScannedFileInfo(mediaInfoResult, "file2.mkv");
@@ -147,7 +148,7 @@ public class TrackViewModelBaseTests
 
         mockBatchConfig.FileConfigurations.Returns(fileConfigurations);
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
         viewModel.SelectedTrack = globalTracks[0];
 
         // Act - enable modification and update track name
@@ -182,7 +183,7 @@ public class TrackViewModelBaseTests
 
         mockBatchConfig.FileConfigurations.Returns(new Dictionary<Guid, FileTrackConfiguration>());
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
         viewModel.SelectedTrack = globalTracks[0];
 
         // Act - Set selected track to null
@@ -222,7 +223,7 @@ public class TrackViewModelBaseTests
 
         mockBatchConfig.FileConfigurations.Returns(new Dictionary<Guid, FileTrackConfiguration>());
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
 
         // Act
         viewModel.SelectedTrack = globalTracks[0];
@@ -247,7 +248,7 @@ public class TrackViewModelBaseTests
         var globalTracks = new List<TrackConfiguration>();
         mockBatchConfig.FileConfigurations.Returns(new Dictionary<Guid, FileTrackConfiguration>());
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
 
         // Act & Assert
         Assert.False(viewModel.IsTrackSelected);
@@ -274,7 +275,7 @@ public class TrackViewModelBaseTests
 
         var file1 = new ScannedFileInfo(mediaInfoResult, "file1.mkv");
         var file1Config = new FileTrackConfiguration { FilePath = file1.Path };
-        file1Config.SubtitleTracks.Add(new TrackConfiguration(trackInfo) { Type = TrackType.Text, Index = 0, Default = false });
+        file1Config.SubtitleTracks.Add(new FileTrackValues { ScannedTrackInfo = trackInfo, Type = TrackType.Text, Index = 0, Default = false, Forced = false, Enabled = false });
 
         var fileConfigurations = new Dictionary<Guid, FileTrackConfiguration>
         {
@@ -283,7 +284,7 @@ public class TrackViewModelBaseTests
 
         mockBatchConfig.FileConfigurations.Returns(fileConfigurations);
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
         viewModel.SelectedTrack = globalTracks[0];
 
         // Act
@@ -315,7 +316,7 @@ public class TrackViewModelBaseTests
 
         var file1 = new ScannedFileInfo(mediaInfoResult, "file1.mkv");
         var file1Config = new FileTrackConfiguration { FilePath = file1.Path };
-        file1Config.SubtitleTracks.Add(new TrackConfiguration(trackInfo) { Type = TrackType.Text, Index = 0, Forced = false });
+        file1Config.SubtitleTracks.Add(new FileTrackValues { ScannedTrackInfo = trackInfo, Type = TrackType.Text, Index = 0, Default = false, Forced = false, Enabled = false });
 
         var fileConfigurations = new Dictionary<Guid, FileTrackConfiguration>
         {
@@ -324,7 +325,7 @@ public class TrackViewModelBaseTests
 
         mockBatchConfig.FileConfigurations.Returns(fileConfigurations);
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
         viewModel.SelectedTrack = globalTracks[0];
 
         // Act
@@ -356,7 +357,7 @@ public class TrackViewModelBaseTests
 
         var file1 = new ScannedFileInfo(mediaInfoResult, "file1.mkv");
         var file1Config = new FileTrackConfiguration { FilePath = file1.Path };
-        file1Config.SubtitleTracks.Add(new TrackConfiguration(trackInfo) { Type = TrackType.Text, Index = 0, Language = MatroskaLanguageOption.Undetermined });
+        file1Config.SubtitleTracks.Add(new FileTrackValues { ScannedTrackInfo = trackInfo, Type = TrackType.Text, Index = 0, Language = MatroskaLanguageOption.Undetermined, Default = false, Forced = false, Enabled = false });
 
         var fileConfigurations = new Dictionary<Guid, FileTrackConfiguration>
         {
@@ -365,7 +366,7 @@ public class TrackViewModelBaseTests
 
         mockBatchConfig.FileConfigurations.Returns(fileConfigurations);
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, globalTracks);
         viewModel.SelectedTrack = globalTracks[0];
 
         var newLanguage = new MatroskaLanguageOption("English", "en", "eng", "eng", "eng");
@@ -407,7 +408,7 @@ public class TrackViewModelBaseTests
         mockBatchConfig.FileList.Returns(fileList);
         mockBatchConfig.FileConfigurations.Returns(new Dictionary<Guid, FileTrackConfiguration>());
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
 
         // Act
         int count0 = viewModel.GetTrackAvailabilityCount(0);
@@ -439,7 +440,7 @@ public class TrackViewModelBaseTests
         mockBatchConfig.FileList.Returns(fileList);
         mockBatchConfig.FileConfigurations.Returns(new Dictionary<Guid, FileTrackConfiguration>());
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
 
         // Act
         string result = viewModel.GetTrackAvailabilityText(0);
@@ -460,7 +461,7 @@ public class TrackViewModelBaseTests
         mockBatchConfig.FileList.Returns(fileList);
         mockBatchConfig.FileConfigurations.Returns(new Dictionary<Guid, FileTrackConfiguration>());
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
 
         // Act & Assert
         Assert.Equal(0, viewModel.TotalFileCount);
@@ -478,7 +479,7 @@ public class TrackViewModelBaseTests
         mockBatchConfig.FileConfigurations.Returns(new Dictionary<Guid, FileTrackConfiguration>());
 
         // Act
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
 
         // Assert
         Assert.True(viewModel.ShowTrackAvailabilityText);
@@ -495,7 +496,7 @@ public class TrackViewModelBaseTests
         mockUIPreferences.ShowTrackAvailabilityText.Returns(false);
         mockBatchConfig.FileConfigurations.Returns(new Dictionary<Guid, FileTrackConfiguration>());
 
-        var viewModel = new TestTrackViewModel(mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
+        var viewModel = new TestTrackViewModel(_mockLogger, mockLanguageProvider, mockBatchConfig, mockUIPreferences, new List<TrackConfiguration>());
         Assert.False(viewModel.ShowTrackAvailabilityText);
 
         // Act

--- a/tests/MatroskaBatchFlow.Uno.UnitTests/Presentation/VideoViewModelTests.cs
+++ b/tests/MatroskaBatchFlow.Uno.UnitTests/Presentation/VideoViewModelTests.cs
@@ -7,6 +7,7 @@ using MatroskaBatchFlow.Core.UnitTests.Builders;
 using MatroskaBatchFlow.Core.Utilities;
 using MatroskaBatchFlow.Uno.Contracts.Services;
 using MatroskaBatchFlow.Uno.Presentation;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 
 namespace MatroskaBatchFlow.Uno.UnitTests.Presentation;
@@ -16,12 +17,14 @@ public class VideoViewModelTests
     private readonly ILanguageProvider _languageProvider;
     private readonly IBatchConfiguration _batchConfiguration;
     private readonly IUIPreferencesService _uiPreferences;
+    private readonly ILogger<VideoViewModel> _logger;
 
     public VideoViewModelTests()
     {
         _languageProvider = Substitute.For<ILanguageProvider>();
         _batchConfiguration = Substitute.For<IBatchConfiguration>();
         _uiPreferences = Substitute.For<IUIPreferencesService>();
+        _logger = Substitute.For<ILogger<VideoViewModel>>();
 
         _languageProvider.Languages.Returns([]);
         _batchConfiguration.VideoTracks.Returns(new ObservableCollection<TrackConfiguration>());
@@ -46,7 +49,7 @@ public class VideoViewModelTests
         _batchConfiguration.VideoTracks.Returns(videoTracks);
 
         // Act
-        var viewModel = new VideoViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new VideoViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.Single(viewModel.VideoTracks);
@@ -70,7 +73,7 @@ public class VideoViewModelTests
         _batchConfiguration.VideoTracks.Returns(videoTracks);
 
         // Act
-        var viewModel = new VideoViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new VideoViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.NotNull(viewModel.SelectedTrack);
@@ -91,7 +94,7 @@ public class VideoViewModelTests
         _batchConfiguration.FileList.Returns(fileList);
 
         // Act
-        var viewModel = new VideoViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new VideoViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.True(viewModel.IsFileListPopulated);
@@ -103,7 +106,7 @@ public class VideoViewModelTests
         // Arrange - fileList is empty by default
 
         // Act
-        var viewModel = new VideoViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new VideoViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         // Assert
         Assert.False(viewModel.IsFileListPopulated);
@@ -116,7 +119,7 @@ public class VideoViewModelTests
         var fileList = new UniqueObservableCollection<ScannedFileInfo>(Substitute.For<IScannedFileInfoPathComparer>());
         _batchConfiguration.FileList.Returns(fileList);
 
-        var viewModel = new VideoViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new VideoViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
         Assert.False(viewModel.IsFileListPopulated);
 
         var mediaInfoResult = new MediaInfoResultBuilder()
@@ -145,7 +148,7 @@ public class VideoViewModelTests
         var videoTracks = new ObservableCollection<TrackConfiguration>();
         _batchConfiguration.VideoTracks.Returns(videoTracks);
 
-        var viewModel = new VideoViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new VideoViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
         Assert.Empty(viewModel.VideoTracks);
 
         var mediaInfoResult = new MediaInfoResultBuilder()
@@ -169,7 +172,7 @@ public class VideoViewModelTests
         var initialTracks = new ObservableCollection<TrackConfiguration>();
         _batchConfiguration.VideoTracks.Returns(initialTracks);
 
-        var viewModel = new VideoViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new VideoViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
 
         var mediaInfoResult = new MediaInfoResultBuilder()
             .WithCreatingLibrary()
@@ -199,7 +202,7 @@ public class VideoViewModelTests
         var videoTracks = new ObservableCollection<TrackConfiguration>();
         _batchConfiguration.VideoTracks.Returns(videoTracks);
 
-        var viewModel = new VideoViewModel(_languageProvider, _batchConfiguration, _uiPreferences);
+        var viewModel = new VideoViewModel(_logger, _languageProvider, _batchConfiguration, _uiPreferences);
         int videoTracksChangedCount = 0;
         viewModel.PropertyChanged += (s, e) =>
         {


### PR DESCRIPTION
Introduce a per-file track values model to ensure that newly added files in a batch are processed correctly during subsequent runs. This update includes a centralized language code resolution method and improves logging for track processing. The changes also ensure that the suppress flag is reset appropriately, preventing files from being skipped.

Previously, per-file track data reused the full TrackConfiguration model, which includes ShouldModify* intent flags. Newly added files received copies with default (false) flags, causing MkvPropeditArgumentsGenerator to skip them entirely even though the user had enabled modifications on the global track. This PR introduces a dedicated FileTrackValues model that carries only data (Name, Language, flags), separating it from the global modification intent. It also includes improved logging for track processing, and a fix for _suppressBatchConfigUpdate not being reset on early return.

### Known limitation
The per-file propagation in UpdateBatchConfigTrackProperty copies the global value identically to every file's FileTrackValues. This is correct for the current use case (uniform batch edits), but I expect it won't scale (properly) to scenarios where per-file values need to differ from the global setting, for example templated track names like "Episode {id} - English" or "Track {n}".

However, such features are not in the works right now, but it is worth considering the impact on them. Furthermore, supporting that would likely require a value expression or template model on the global TrackConfiguration, per-file resolution against file/track metadata, and possibly a third state distinguishing "use global template" from "per-file override". The current two-tier split (TrackConfiguration for intent + FileTrackValues for data) is a reasonable foundation for that future work.

Fixes #85